### PR TITLE
Trim term in suggester

### DIFF
--- a/lib/jquery.ui/jquery.ui.suggester.js
+++ b/lib/jquery.ui/jquery.ui.suggester.js
@@ -486,7 +486,7 @@ $.widget( 'ui.suggester', {
 		this._clearTimeout();
 		this._searching = true;
 
-		this._term = this.element.val();
+		this._term = $.trim( this.element.val() );
 
 		if( this._term.length < this.options.minTermLength ) {
 			this._close();


### PR DESCRIPTION
Currently you can hit space and get all suggestions. I don't think this is a useful feature.

Example: Edit the language of a monolingual text value. Type "de". Now hit space. Wait. Hit space again.