### PR TITLE
Defer ExpertExtender construction in tests

### DIFF
--- a/tests/src/ExpertExtender/ExpertExtender.CalendarHint.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.CalendarHint.tests.js
@@ -23,16 +23,11 @@
 		} );
 	}
 
-	testExpertExtenderExtension.constructor(
+	testExpertExtenderExtension.all(
 		ExpertExtender.CalendarHint,
-		new ExpertExtender.CalendarHint()
-	);
-	testExpertExtenderExtension.destroy(
-		ExpertExtender.CalendarHint,
-		new ExpertExtender.CalendarHint()
-	);
-	testExpertExtenderExtension.init(
-		new ExpertExtender.CalendarHint()
+		function() {
+			return new ExpertExtender.CalendarHint();
+		}
 	);
 
 	QUnit.test( 'calendarhint is hidden if it should not be shown', function( assert ) {

--- a/tests/src/ExpertExtender/ExpertExtender.Container.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.Container.tests.js
@@ -14,16 +14,11 @@
 		} );
 	}
 
-	testExpertExtenderExtension.constructor(
+	testExpertExtenderExtension.all(
 		ExpertExtender.Container,
-		new ExpertExtender.Container( $( '<div />' ), {} )
-	);
-	testExpertExtenderExtension.destroy(
-		ExpertExtender.Container,
-		new ExpertExtender.Container( $( '<div />' ), {} )
-	);
-	testExpertExtenderExtension.init(
-		new ExpertExtender.Container( $( '<div />' ), {} )
+		function() {
+			return new ExpertExtender.Container( $( '<div />' ), {} );
+		}
 	);
 
 	QUnit.test( 'init calls child', function( assert ) {

--- a/tests/src/ExpertExtender/ExpertExtender.LanguageSelector.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.LanguageSelector.tests.js
@@ -17,16 +17,11 @@
 		);
 	}
 
-	testExpertExtenderExtension.constructor(
+	testExpertExtenderExtension.all(
 		ExpertExtender.LanguageSelector,
-		new ExpertExtender.LanguageSelector( new util.MessageProvider(), function() { } )
-	);
-	testExpertExtenderExtension.destroy(
-		ExpertExtender.LanguageSelector,
-		new ExpertExtender.LanguageSelector( new util.MessageProvider(), function() { } )
-	);
-	testExpertExtenderExtension.init(
-		new ExpertExtender.LanguageSelector( new util.MessageProvider(), function() { } )
+		function() {
+			return new ExpertExtender.LanguageSelector( new util.MessageProvider(), function() { } );
+		}
 	);
 
 	QUnit.test( 'value does not change if upstream value changes', function( assert ) {

--- a/tests/src/ExpertExtender/ExpertExtender.Listrotator.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.Listrotator.tests.js
@@ -14,17 +14,11 @@
 		} );
 	}
 
-	testExpertExtenderExtension.constructor(
-		ExpertExtender.Listrotator,
-		new ExpertExtender.Listrotator( '', [ { value: 'value', label: 'label' } ] )
-	);
-	testExpertExtenderExtension.destroy(
-		ExpertExtender.Listrotator,
-		new ExpertExtender.Listrotator( '', [ { value: 'value', label: 'label' } ] )
-	);
-	testExpertExtenderExtension.init(
-		new ExpertExtender.Listrotator( '', [ { value: 'value', label: 'label' } ] )
-	);
+	function getInstance() {
+		return new ExpertExtender.Listrotator( '', [ { value: 'value', label: 'label' } ] );
+	}
+
+	testExpertExtenderExtension.all( ExpertExtender.Listrotator, getInstance );
 
 	QUnit.test( 'supports custom values', function( assert ) {
 		var getUpstreamValue = function() {

--- a/tests/src/ExpertExtender/ExpertExtender.Preview.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.Preview.tests.js
@@ -14,16 +14,11 @@
 		} );
 	}
 
-	testExpertExtenderExtension.constructor(
+	testExpertExtenderExtension.all(
 		ExpertExtender.Preview,
-		new ExpertExtender.Preview( null )
-	);
-	testExpertExtenderExtension.destroy(
-		ExpertExtender.Preview,
-		new ExpertExtender.Preview( null )
-	);
-	testExpertExtenderExtension.init(
-		new ExpertExtender.Preview( null )
+		function() {
+			return new ExpertExtender.Preview( null );
+		}
 	);
 
 } )(

--- a/tests/src/ExpertExtender/ExpertExtender.Toggler.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.Toggler.tests.js
@@ -14,16 +14,11 @@
 		} );
 	}
 
-	testExpertExtenderExtension.constructor(
+	testExpertExtenderExtension.all(
 		ExpertExtender.Toggler,
-		new ExpertExtender.Toggler( new util.MessageProvider(), $( '<div />' ) )
-	);
-	testExpertExtenderExtension.destroy(
-		ExpertExtender.Toggler,
-		new ExpertExtender.Toggler( new util.MessageProvider(), $( '<div />' ) )
-	);
-	testExpertExtenderExtension.init(
-		new ExpertExtender.Toggler( new util.MessageProvider(), $( '<div />' ) )
+		function() {
+			return new ExpertExtender.Toggler( new util.MessageProvider(), $( '<div />' ) );
+		}
 	);
 
 } )(

--- a/tests/src/ExpertExtender/testExpertExtenderExtension.js
+++ b/tests/src/ExpertExtender/testExpertExtenderExtension.js
@@ -7,32 +7,47 @@
 
 	valueview.tests = valueview.tests || {};
 	valueview.tests.testExpertExtenderExtension = {
-		constructor: function( constructor, instance ) {
+		all: function( constructor, getInstance ) {
+			this.constructor( constructor, getInstance );
+			this.destroy( constructor, getInstance );
+			this.init( getInstance );
+		},
+
+		constructor: function( constructor, getInstance ) {
 			QUnit.test( 'Constructor', function( assert ) {
+				var instance = getInstance();
+
 				assert.ok(
 					instance instanceof constructor,
 					'Instantiated.'
 				);
 
 				assert.notDeepEqual( instance, constructor.prototype );
+
+				instance.destroy();
 			} );
 		},
 
-		destroy: function( constructor, instance ) {
+		destroy: function( constructor, getInstance ) {
 			QUnit.test( 'destroy cleans up properties', function( assert ) {
+				var instance = getInstance();
+
 				instance.destroy();
 
 				assert.deepEqual( instance, constructor.prototype );
 			} );
 		},
 
-		init: function( instance ) {
+		init: function( getInstance ) {
 			QUnit.test( 'init appends an element', function( assert ) {
+				var instance = getInstance();
 				var $extender = $( '<div />' );
 
 				instance.init( $extender );
 
 				assert.notEqual( $extender.children().length, 0 );
+
+				instance.destroy();
 			} );
 		}
 	};


### PR DESCRIPTION
listrotator creates DOM nodes in _create when called through
`new ExpertExtender.Listrotator()`, which then mess up the listrotator tests.

Also simplifies the ExpertExtender tests and calls destroy() in all of them.