### PR TITLE
Use "0" for comfort zone calculation

### DIFF
--- a/lib/jquery/jquery.inputautoexpand.js
+++ b/lib/jquery/jquery.inputautoexpand.js
@@ -247,7 +247,7 @@ $.extend( $.AutoExpandInput.prototype, {
 	 */
 	_getWidthFor: function( text ) {
 		$rulerX.html( escaped( text ) );
-		return $rulerX.width();
+		return Math.ceil( $rulerX.width() );
 	},
 
 	/**
@@ -267,7 +267,7 @@ $.extend( $.AutoExpandInput.prototype, {
 			return 0;
 		}
 		// Don't need comfort zone in this case, just some sane space:
-		return Math.ceil( this._getWidthFor( this.$input.attr( 'placeholder' ) + ' ' ) );
+		return this._getWidthFor( this.$input.attr( 'placeholder' ) + '0' );
 	},
 
 	/**
@@ -315,8 +315,8 @@ $.extend( $.AutoExpandInput.prototype, {
 	_getComfortZone: function() {
 		return ( this._options.comfortZone )
 			? this._options.comfortZone
-			// IE does not recognize a single space character, using some narrow character instead:
-			: Math.ceil( this._getWidthFor( 'I' ) * 2 );
+			// IE does not recognize space characters, using 2ch CSS units instead:
+			: this._getWidthFor( '00' );
 	},
 
 	/**


### PR DESCRIPTION
This is a direct follow-up to #142.

My issue with the "I" is that it's width is very, very diverse across fonts. It's only 1 pixel in some fonts but much, much more in others. I'm preferring "e" (as in `em`) or "W" (for a wide character).