### PR TITLE
Remove inverted language map from LanguageSelector

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Other methods an Expert needs to provide:
 ## Release notes
 
 ### 0.11.0 (dev)
+
+#### Behaviour changes
+
 * `jQuery.ui.toggler`: Added parameter to `animation` event determining whether the toggler's subject will be visible or hidden.
 * `jQuery.ui.toggler`: Changed `_reflectVisibilityOnToggleIcon` to be private.
 * `jQuery.ui.toggler`: Added `refresh` function to be able to reflect visibility changes to the toggler's subject that have been applied externally.

--- a/lib/jquery.ui/jquery.ui.languagesuggester.js
+++ b/lib/jquery.ui/jquery.ui.languagesuggester.js
@@ -1,15 +1,42 @@
 ( function( $ ) {
 	'use strict';
 
+var PARENT = $.ui.suggester;
+
 /**
  * @class jQuery.ui.languagesuggester
  * @extends jQuery.ui.suggester
  * @licence GNU GPL v2+
  * @author Thiemo Mättig
+ * @author Adrian Heine < adrian.heine@wikimedia.de >
  *
  * @constructor
  */
-$.widget( 'ui.languagesuggester', $.ui.suggester, {
+$.widget( 'ui.languagesuggester', PARENT, {
+	/**
+	 * @property {jQuery.ui.ooMenu.Item|null}
+	 * @protected
+	 */
+	_selectedItem: null,
+
+	/**
+	 * @inheritdoc
+	 * @protected
+	 */
+	_initMenu: function( ooMenu ) {
+		var self = this, retVal;
+
+		retVal = PARENT.prototype._initMenu.apply( this, arguments );
+
+		$( retVal )
+		.on( 'selected.languagesuggester', function( event, item ) {
+			self._selectedItem = item;
+			self.element.val( item.getLabel() );
+		} );
+
+		return retVal;
+	},
+
 	/**
 	 * @inheritdoc
 	 * @protected
@@ -19,29 +46,43 @@ $.widget( 'ui.languagesuggester', $.ui.suggester, {
 			deferred = $.Deferred(),
 			regex = this._escapeRegex( term ),
 			matcher = new RegExp( regex, 'i' ),
+			subCodeMatcher = new RegExp( '^' + regex + '-', 'i' ),
+			prefixMatcher =  new RegExp( '^' + regex, 'i' ),
 			promoters = [
-				new RegExp( '\\(' + regex + '\\)', 'i' ),
-				new RegExp( '\\(' + regex + '-', 'i' ),
-				new RegExp( '^' + regex, 'i' ),
-				new RegExp( '\\(' + regex, 'i' )
+				function( item ) { return item.code.toLowerCase() === term.toLowerCase(); },
+				function( item ) { return subCodeMatcher.test( item.code ); },
+				function( item ) { return prefixMatcher.test( item.label ); },
+				function( item ) { return prefixMatcher.test( item.code ); },
 			];
 
 		deferred.resolve( $.grep( source, function( item ) {
-			return matcher.test( item );
+			return matcher.test( item.code ) || matcher.test( item.label );
 		} ).sort( function( a, b ) {
 			for( var i = 0; i < promoters.length; i++ ) {
-				var promoterA = promoters[i].test( a ),
-					promoterB = promoters[i].test( b );
+				var promoterA = promoters[i]( a ),
+					promoterB = promoters[i]( b );
 
 				if( promoterA !== promoterB ) {
 					return promoterB - promoterA;
 				}
 			}
 
-			return self._localeCompare( a, b );
+			return self._localeCompare( a.label, b.label );
 		} ), term );
 
 		return deferred.promise();
+	},
+
+	/**
+	 * Instantiates a menu item instance from a suggestion.
+	 * @protected
+	 *
+	 * @param {object} suggestion
+	 * @param {string} requestTerm
+	 * @return {jQuery.ui.ooMenu.Item}
+	 */
+	_createMenuItemFromSuggestion: function( suggestion, requestTerm ) {
+		return new $.ui.ooMenu.Item( suggestion.label, suggestion.code );
 	},
 
 	/**
@@ -55,6 +96,13 @@ $.widget( 'ui.languagesuggester', $.ui.suggester, {
 		return a.localeCompare
 			? a.localeCompare( b )
 			: ( a.toUpperCase() < b.toUpperCase() ? -1 : 1 );
+	},
+
+	/**
+	 * @return {jQuery.ui.ooMenu.Item|null}
+	 */
+	getSelectedItem: function() {
+		return this._selectedItem;
 	}
 } );
 


### PR DESCRIPTION
This helps in T86653 since it allows us to narrow the interface of the
ContentLanguages service.

It has one issue, though: After selecting a language, the input now only shows
the language code. Previously, it was the same string as shown in the menu,
i. e. `name (code)` in English.

@lydiapintscher @snaterlicious @thiemowmde 