### PR TITLE
Updated jQuery.ui.toggler

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ Other methods an Expert needs to provide:
 
 ## Release notes
 
-### 0.10.1 (dev)
+### 0.11.0 (dev)
+* `jQuery.ui.toggler`: Added parameter to `animation` event determining whether the toggler's subject will be visible or hidden.
+* `jQuery.ui.toggler`: Changed `_reflectVisibilityOnToggleIcon` to be private.
+* `jQuery.ui.toggler`: Added `refresh` function to be able to reflect visibility changes to the toggler's subject that have been applied externally.
 
 #### Bugfixes
 * `$.fn.inputautoexpand`: Fixed height expansion mechanism.

--- a/ValueView.php
+++ b/ValueView.php
@@ -5,7 +5,7 @@ if ( defined( 'VALUEVIEW_VERSION' ) ) {
 	return 1;
 }
 
-define( 'VALUEVIEW_VERSION', '0.10.1-dev' );
+define( 'VALUEVIEW_VERSION', '0.11.0-dev' );
 
 /**
  * @deprecated

--- a/lib/jquery.ui/jquery.ui.toggler.css
+++ b/lib/jquery.ui/jquery.ui.toggler.css
@@ -13,6 +13,7 @@
 }
 .ui-toggler .ui-toggler-icon,
 .ui-toggler .ui-toggler-label {
+	cursor: pointer;
 	display: inline-block;
 	vertical-align: middle;
 }

--- a/lib/jquery.ui/jquery.ui.toggler.js
+++ b/lib/jquery.ui/jquery.ui.toggler.js
@@ -32,9 +32,9 @@ $( document ).ready( function() {
  * The toggler hides a references subject node an toggles its visibility whenever clicking the
  * element the toggler is initialized on. The toggler considers the subject's current "display"
  * style, so if it is set to "none", it is considered invisible initially.
- * (uses `jQuery.animateWithEvent`)
  * @class jQuery.ui.toggler
  * @extends jQuery.Widget
+ * @uses jQuery.animateWithEvent
  * @licence GNU GPL v2+
  * @author H. Snater < mediawiki@snater.com >
  * @author Daniel Werner < danweetz@web.de >
@@ -49,13 +49,14 @@ $( document ).ready( function() {
  * @event animation
  * Triggered at the beginning of toggler animations.
  * @param {jQuery.AnimationEvent} event
+ * @param {Object} params
+ * @param {boolean} params.visible Whether the subject is toggled to be visible.
  */
 $.widget( 'ui.toggler', {
 
 	/**
 	 * @see jQuery.Widget.options
 	 * @protected
-	 * @readonly
 	 */
 	options: {
 		$subject: null
@@ -99,25 +100,25 @@ $.widget( 'ui.toggler', {
 		.addClass( this.widgetBaseClass + ' ' + this.widgetBaseClass + '-toggle '
 			+ 'ui-state-default' );
 
-		if( this.element[0].nodeName === 'A' ) {
-			this.element.attr( 'href', 'javascript:void(0);' );
-		}
-
 		this.$toggleIcon = $( '<span/>' )
 		.addClass( this.widgetBaseClass + '-icon ui-icon' );
 
 		this.element
 		.on( 'click.' + this.widgetName, function( event ) {
+			event.preventDefault();
+
 			if( !self.element.hasClass( 'ui-state-disabled' ) ) {
 				// Change toggle icon to reflect current state of toggle subject visibility:
-				self._reflectVisibilityOnToggleIcon( true );
+				var visible = self._reflectVisibilityOnToggleIcon( true );
 
 				self.options.$subject.stop().animateWithEvent(
 					'togglerstatetransition',
 					'slideToggle',
 					self.options,
 					function( animationEvent ) {
-						self._trigger( 'animation', animationEvent );
+						self._trigger( 'animation', animationEvent, {
+							visible: visible
+						} );
 					}
 				);
 			}
@@ -147,9 +148,10 @@ $.widget( 'ui.toggler', {
 
 	/**
 	 * Reflects the toggler's subject visibility in the toggler's icon.
-	 * @protected
+	 * @private
 	 *
 	 * @param {boolean} [inverted]
+	 * @return {boolean} Whether the subject is toggled to be visible.
 	 */
 	_reflectVisibilityOnToggleIcon: function( inverted ) {
 		var iconClass = 'ui-icon-triangle-1-',
@@ -172,24 +174,16 @@ $.widget( 'ui.toggler', {
 
 		this.element[ visible ? 'removeClass' : 'addClass' ](
 			this.widgetBaseClass + '-toggle-collapsed' );
+
+		return visible;
 	},
 
 	/**
-	 * @see jQuery.Widget.disable
-	 * @protected
+	 * Refreshes the toggler's state.
 	 */
-	disable: function() {
-		this.element.addClass( 'ui-state-disabled' );
-	},
-
-	/**
-	 * @see jQuery.Widget.enable
-	 * @protected
-	 */
-	enable: function() {
-		this.element.removeClass( 'ui-state-disabled' );
+	refresh: function() {
+		this._reflectVisibilityOnToggleIcon();
 	}
-
 } );
 
 } )( jQuery );

--- a/tests/lib/jquery.ui/jquery.ui.toggler.tests.js
+++ b/tests/lib/jquery.ui/jquery.ui.toggler.tests.js
@@ -2,14 +2,11 @@
  * @licence GNU GPL v2+
  * @author H. Snater < mediawiki@snater.com >
  */
-
 ( function( $, QUnit ) {
 	'use strict';
 
 	/**
-	 * Factory for creating an toggler widget suitable for testing.
-	 *
-	 * @param {Object} options
+	 * @param {Object} [options={}]
 	 * @return {jQuery.ui.toggler}
 	 */
 	var newTestToggler = function( options ) {
@@ -19,7 +16,7 @@
 			.text( 'test' )
 			.appendTo( 'body' );
 
-		options = $.extend( { $subject: $defaultDiv }, options );
+		options = $.extend( { $subject: $defaultDiv }, options || {} );
 
 		var $div = $( '<div/>' )
 			.addClass( 'test_toggler' )
@@ -29,7 +26,7 @@
 		return $div.data( 'toggler' );
 	};
 
-	QUnit.module( 'jquery.ui.toggler', QUnit.newMwEnvironment( {
+	QUnit.module( 'jquery.ui.toggler', {
 		teardown: function() {
 			$( '.test_toggler' ).each( function( i, node ) {
 				if( $( node ).data( 'toggler' ) ) {
@@ -39,7 +36,7 @@
 			} );
 			$( '.test_toggler-subject' ).remove();
 		}
-	} ) );
+	} );
 
 	QUnit.test( 'Initialization and destruction', 3, function( assert ) {
 		var toggler = newTestToggler();


### PR DESCRIPTION
* Added parameter to `animation` event determining whether the toggler's subject will be visible or hidden.
* Changed `_reflectVisibilityOnToggleIcon` to be private.
* Added `refresh` function to be able to reflect visibility changes to the toggler's subject that have been applied externally.
* Removed pointless `disable` and `enable` functions as those are covered by jQuery.Widget natively.

Needed for https://phabricator.wikimedia.org/T86193