### PR TITLE
Removed inefficient mocking of native jQuery.Widget functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Other methods an `Expert` needs to provide:
 
 #### Breaking changes
 * Removed deprecated constant `ValueView_VERSION`, use `VALUEVIEW_VERSION` instead.
+* Removed `jQuery.valueview.disable`, `jQuery.valueview.enable` and `jQuery.valueview.isDisabled`. These function were used to mock native `jQuery.Widget` functionality while adding a full `draw` cycle on top. `jQuery.valueview.draw` does not consider the state anymore.
 
 ### 0.14.5 (2015-06-11)
 * Fixed `jQuery.valueview.ExpertExtender.CalendarHint` test broken due to DataValues JavaScript dependency update.

--- a/src/jquery.valueview.ViewState.js
+++ b/src/jquery.valueview.ViewState.js
@@ -43,11 +43,11 @@ jQuery.valueview = jQuery.valueview || {};
 		},
 
 		/**
-		 * @see jQuery.valueview.isDisabled
-		 * @inheritdoc jQuery.valueview#isDisabled
+		 * Returns whether the related `valueview` is currently disabled.
+		 * @return {boolean}
 		 */
 		isDisabled: function() {
-			return this._view.isDisabled();
+			return this._view.option( 'disabled' );
 		},
 
 		/**

--- a/src/jquery.valueview.valueview.js
+++ b/src/jquery.valueview.valueview.js
@@ -184,6 +184,7 @@ $.widget( 'valueview.valueview', PARENT, {
 		language: null,
 		autoStartEditing: false,
 		parseDelay: 300,
+		messageProvider: null,
 		contentLanguages: null
 	},
 
@@ -580,19 +581,9 @@ $.widget( 'valueview.valueview', PARENT, {
 	draw: function() {
 		var self = this;
 
-		// have native $.Widget functionality add/remove state css classes
-		// (see jQuery.Widget._setOption)
-		PARENT.prototype.option.call( this, 'disabled', this.isDisabled() );
-
-		// add/remove edit mode ui class:
-		var staticModeClass = this.widgetBaseClass + '-instaticmode',
-			editModeClass = this.widgetBaseClass + '-ineditmode';
-
-		if( this.isInEditMode() ) {
-			this.element.addClass( editModeClass ).removeClass( staticModeClass );
-		} else {
-			this.element.addClass( staticModeClass ).removeClass( editModeClass );
-		}
+		this.element
+			.toggleClass( this.widgetBaseClass + '-instaticmode', !this._isInEditMode )
+			.toggleClass( this.widgetBaseClass + '-ineditmode', this._isInEditMode );
 
 		return this.drawContent()
 			.done( function() {
@@ -643,47 +634,6 @@ $.widget( 'valueview.valueview', PARENT, {
 	 */
 	drawStaticContent: function() {
 		this.element.html( this.getFormattedValue() );
-	},
-
-	/**
-	 * @private
-	 *
-	 * @param {boolean} disabledValue
-	 */
-	_setDisabled: function( disabledValue ) {
-		if( this.options.disabled !== disabledValue ) {
-			this.options.disabled = disabledValue;
-			this.draw();
-		}
-	},
-
-	/**
-	 * Marks the `valueview` disabled and triggers re-drawing it.
-	 * Since the visual state should be managed completely by the `draw` method, toggling the css
-	 * classes is done in `draw()` by issuing a call to `jQuery.Widget.option()`.
-	 * @see jQuery.Widget.disable
-	 */
-	disable: function() {
-		this._setDisabled( true );
-	},
-
-	/**
-	 * Marks the `valueview` enabled and triggers re-drawing the `valueview`.
-	 * Since the visual state should be managed completely by the `draw` method, toggling the css
-	 * classes is done in `draw()` by issuing a call to `jQuery.Widget.option()`.
-	 * @see jQuery.Widget.enable
-	 */
-	enable: function() {
-		this._setDisabled( false );
-	},
-
-	/**
-	 * Returns whether the `valueview` is disabled.
-	 *
-	 * @return {boolean}
-	 */
-	isDisabled: function() {
-		return this.option( 'disabled' );
 	},
 
 	/**

--- a/tests/src/jquery.valueview.valueview.tests.js
+++ b/tests/src/jquery.valueview.valueview.tests.js
@@ -188,24 +188,6 @@
 		} );
 	} );
 
-	QUnit.test( 'disable', function( assert ) {
-		initVv();
-
-		vvInst.disable();
-
-		assert.ok( vvInst.isDisabled() );
-		assert.ok( vvInst.option( 'disabled' ) );
-	} );
-
-	QUnit.test( 'enable', function( assert ) {
-		initVv();
-
-		vvInst.enable();
-
-		assert.ok( !vvInst.isDisabled() );
-		assert.ok( !vvInst.option( 'disabled' ) );
-	} );
-
 } )(
 	jQuery,
 	jQuery.valueview,


### PR DESCRIPTION
Removed `jQuery.valueview.disable`, `jQuery.valueview.enable` and `jQuery.valueview.isDisabled`.
These function were used to mock native `jQuery.Widget` functionality while adding a full `draw`
cycle on top. `jQuery.valueview.draw` does not consider the state anymore.