### PR TITLE
CommonsMedia: Make file repo URI configurable

### DIFF
--- a/lib/jquery.ui/jquery.ui.commonssuggester.js
+++ b/lib/jquery.ui/jquery.ui.commonssuggester.js
@@ -36,7 +36,7 @@
 				var deferred = $.Deferred();
 
 				$.ajax( {
-					url: location.protocol + '//commons.wikimedia.org/w/api.php',
+					url: wb.sites.getSiteByGlobalId( wbRepo.commonsSiteId )._siteDetails.apiUrl,
 					dataType: 'jsonp',
 					data: {
 						search: term,


### PR DESCRIPTION
This allows another file repo for commons.

It requires another patch to Wikibase that is located on gerrit.

Bug: [T90492](https://phabricator.wikimedia.org/T90492)