### PR TITLE
Handle browsers which cannot focus in test cases

### DIFF
--- a/tests/lib/jquery.ui/jquery.ui.inputextender.tests.js
+++ b/tests/lib/jquery.ui/jquery.ui.inputextender.tests.js
@@ -117,14 +117,14 @@
 
 	QUnit.test( 'Initialization on focused input', function( assert ) {
 		var $input = $( '<input/>' ).appendTo( $( 'body' ) ).focus();
+		if( !$input.is( ':focus' ) ) {
+			assert.ok( true, 'Could not test since focussing does not work.' );
+			return;
+		}
 		var extender = newTestInputextender( $input );
 		var isOk = extender.extensionIsActive();
 
-		if( !isOk && 'hidden' in document && document.hidden ) {
-			assert.ok( true, 'Could not test since browser window is not focused' );
-		} else {
-			assert.ok( isOk, 'Extension active initially because input has focus.' );
-		}
+		assert.ok( isOk, 'Extension active initially because input has focus.' );
 	} );
 
 	QUnit.test( 'Destruction', 2, function( assert ) {

--- a/tests/lib/jquery/jquery.focusAt.tests.js
+++ b/tests/lib/jquery/jquery.focusAt.tests.js
@@ -128,6 +128,15 @@
 		$( ':focus' ).blur();
 		elem.appendTo( $dom );
 
+		// Check if focussing actually works
+		elem.focus();
+		if( !elem.is( ':focus' ) ) {
+			assert.ok( 'Could not test because focussing does not work.' );
+			return;
+		}
+		elem.blur();
+		assert.ok( !elem.is( ':focus' ) );
+
 		assert.ok(
 			elem.focusAt( 0 ),
 			'Can call focusAt on element in DOM'
@@ -141,11 +150,7 @@
 			);
 		} else {
 			isOk = $( ':focus' ).filter( elem ).length;
-			if( !isOk && 'hidden' in document && document.hidden ) {
-				assert.ok( true, 'Could not test since browser window is not focused' );
-			} else {
-				assert.ok( isOk, 'Focused element has focus set.' );
-			}
+			assert.ok( isOk, 'Focused element has focus set.' );
 		}
 		elem.remove();
 	} );

--- a/tests/src/ExpertExtender/ExpertExtender.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.tests.js
@@ -56,18 +56,18 @@
 			} ] );
 
 		$input.focus();
-
-		// inputextender immediately extends if $input has focus
 		expertExtender.init();
+		// inputextender immediately extends if $input has focus
+		// If, after focussing, $input does not have focus, we are running in phantomjs
+		// or an unfocused firefox window. Force showing the extension, then.
+		if( !$input.is( ':focus' ) ) {
+			expertExtender._inputextender.showExtension();
+		}
 
 		window.setTimeout( function() {
-			if( !init.called && 'hidden' in document && document.hidden ) {
-				assert.ok( true, 'Could not test since browser window is not focused' );
-			} else {
-				sinon.assert.calledOnce( init );
-				sinon.assert.calledOnce( onInitialShow );
-				sinon.assert.calledOnce( draw );
-			}
+			sinon.assert.calledOnce( init );
+			sinon.assert.calledOnce( onInitialShow );
+			sinon.assert.calledOnce( draw );
 
 			$input.remove();
 


### PR DESCRIPTION
The previous solution only worked for background windows of browsers
with Page Visibility API (i. e. Firefox), but did not work for browsers
which can't really handle focus at all (PhantomJS).

Please test this in Firefox with a hidden browser window or in PhantomJS.