### PR TITLE
Don't explicitly depend on jquery.qunit

### DIFF
--- a/tests/src/ExpertExtender/ExpertExtender.CalendarHint.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.CalendarHint.tests.js
@@ -17,7 +17,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.CalendarHint' );
 
-	if( QUnit.urlParams.completenesstest ) {
+	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( ExpertExtender.CalendarHint.prototype, function( cur, tester, path ) {
 			return false;
 		} );
@@ -150,5 +150,5 @@
 	util.HashMessageProvider,
 	sinon,
 	QUnit,
-	CompletenessTest
+	typeof CompletenessTest !== 'undefined' ? CompletenessTest : null
 );

--- a/tests/src/ExpertExtender/ExpertExtender.Container.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.Container.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.Container' );
 
-	if( QUnit.urlParams.completenesstest ) {
+	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( ExpertExtender.Container.prototype, function( cur, tester, path ) {
 			return false;
 		} );
@@ -40,5 +40,5 @@
 	jQuery.valueview.tests.testExpertExtenderExtension,
 	sinon,
 	QUnit,
-	CompletenessTest
+	typeof CompletenessTest !== 'undefined' ? CompletenessTest : null
 );

--- a/tests/src/ExpertExtender/ExpertExtender.LanguageSelector.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.LanguageSelector.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.LanguageSelector' );
 
-	if( QUnit.urlParams.completenesstest ) {
+	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest(
 			ExpertExtender.LanguageSelector.prototype,
 			function( cur, tester, path ) {
@@ -104,5 +104,5 @@
 	jQuery.valueview.tests.testExpertExtenderExtension,
 	sinon,
 	QUnit,
-	CompletenessTest
+	typeof CompletenessTest !== 'undefined' ? CompletenessTest : null
 );

--- a/tests/src/ExpertExtender/ExpertExtender.Listrotator.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.Listrotator.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.Listrotator' );
 
-	if( QUnit.urlParams.completenesstest ) {
+	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( ExpertExtender.Listrotator.prototype, function( cur, tester, path ) {
 			return false;
 		} );
@@ -82,5 +82,5 @@
 	jQuery.valueview.tests.testExpertExtenderExtension,
 	sinon,
 	QUnit,
-	CompletenessTest
+	typeof CompletenessTest !== 'undefined' ? CompletenessTest : null
 );

--- a/tests/src/ExpertExtender/ExpertExtender.Preview.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.Preview.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.Preview' );
 
-	if( QUnit.urlParams.completenesstest ) {
+	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( ExpertExtender.Preview.prototype, function( cur, tester, path ) {
 			return false;
 		} );
@@ -29,5 +29,5 @@
 	jQuery.valueview.tests.testExpertExtenderExtension,
 	sinon,
 	QUnit,
-	CompletenessTest
+	typeof CompletenessTest !== 'undefined' ? CompletenessTest : null
 );

--- a/tests/src/ExpertExtender/ExpertExtender.Toggler.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.Toggler.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.Toggler' );
 
-	if( QUnit.urlParams.completenesstest ) {
+	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( ExpertExtender.Toggler.prototype, function( cur, tester, path ) {
 			return false;
 		} );
@@ -28,5 +28,5 @@
 	util,
 	sinon,
 	QUnit,
-	CompletenessTest
+	typeof CompletenessTest !== 'undefined' ? CompletenessTest : null
 );

--- a/tests/src/ExpertExtender/ExpertExtender.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender' );
 
-	if( QUnit.urlParams.completenesstest ) {
+	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( ExpertExtender.prototype, function( cur, tester, path ) {
 			return false;
 		} );
@@ -75,4 +75,10 @@
 		}, 0 );
 	} );
 
-} )( jQuery, jQuery.valueview.ExpertExtender, sinon, QUnit, CompletenessTest );
+} )(
+	jQuery,
+	jQuery.valueview.ExpertExtender,
+	sinon,
+	QUnit,
+	typeof CompletenessTest !== 'undefined' ? CompletenessTest : null
+);

--- a/tests/src/jquery.valueview.valueview.tests.js
+++ b/tests/src/jquery.valueview.valueview.tests.js
@@ -12,7 +12,7 @@
 
 	QUnit.module( 'jquery.valueview.valueview' );
 
-	if( QUnit.urlParams.completenesstest ) {
+	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( vv.prototype, function( cur, tester, path ) {
 			// Don't check code coverage for options
 			return path[path.length - 1] === 'options';
@@ -206,4 +206,13 @@
 		assert.ok( !vvInst.option( 'disabled' ) );
 	} );
 
-} )( jQuery, jQuery.valueview, dataValues, valueFormatters, valueParsers, sinon, QUnit, CompletenessTest );
+} )(
+	jQuery,
+	jQuery.valueview,
+	dataValues,
+	valueFormatters,
+	valueParsers,
+	sinon,
+	QUnit,
+	typeof CompletenessTest !== 'undefined' ? CompletenessTest : null
+);

--- a/tests/src/resources.php
+++ b/tests/src/resources.php
@@ -36,7 +36,6 @@ return call_user_func( function() {
 			),
 			'dependencies' => array(
 				'dataValues.values',
-				'jquery.qunit.completenessTest',
 				'jquery.valueview.valueview',
 				'test.sinonjs',
 				'valueFormatters.formatters',


### PR DESCRIPTION
Explicitly depending on jquery.qunit breaks qunit-karma-based test running,
since qunit-karma loads its own QUnit instance. This closes [T94395](https://phabricator.wikimedia.org/T94395).