### PR TITLE
Implement UnDeserializableValue expert

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Other methods an `Expert` needs to provide:
 
 ## Release notes
 
+### 0.14.4 (2015-06-08)
+* Added expert for `UnDeserializableValue`s.
+
 ### 0.14.3 (2015-04-02)
 * Fix premature afterparse handling (e.g. save) of parsed values.
 

--- a/ValueView.php
+++ b/ValueView.php
@@ -5,7 +5,7 @@ if ( defined( 'VALUEVIEW_VERSION' ) ) {
 	return 1;
 }
 
-define( 'VALUEVIEW_VERSION', '0.14.3' );
+define( 'VALUEVIEW_VERSION', '0.14.4' );
 
 /**
  * @deprecated

--- a/src/experts/UnDeserializableValue.js
+++ b/src/experts/UnDeserializableValue.js
@@ -1,0 +1,52 @@
+( function( $, vv ) {
+	'use strict';
+
+	var PARENT = vv.Expert;
+
+	/**
+	 * `Valueview` expert for displaying (or rather not displaying) a data value not supported by
+	 * the `valueview` UI because there is not specialised expert devoted to that data value type.
+	 * @class jQuery.valueview.experts.UnsupportedValue
+	 * @extends jQuery.valueview.Expert
+	 * @since 0.1
+	 * @licence GNU GPL v2+
+	 * @author Daniel Werner < daniel.werner@wikimedia.de >
+	 * @author Katie Filbert < aude.wiki@gmail.com >
+	 */
+	vv.experts.UnDeserializableValue = vv.expert( 'UnDeserializableValue', PARENT, {
+		/**
+		 * @inheritdoc
+		 * @protected
+		 */
+		_options: {
+			messages: {
+				'valueview-expert-undeserializablevalue':
+					'The value is invalid and cannot be displayed.'
+			}
+		},
+
+		/**
+		 * @inheritdoc
+		 */
+		rawValue: function() {
+			return this.viewState().getTextValue();
+		},
+
+		/**
+		 * @inheritdoc
+		 * @protected
+		 */
+		_init: function() {
+			// reuse the existing formatted message
+			this.$viewPort.html( this._viewState.getFormattedValue() );
+		},
+
+		/**
+		 * @inheritdoc
+		 */
+		draw: function() {
+			return $.Deferred().resolve().promise();
+		}
+	} );
+
+}( jQuery, jQuery.valueview ) );

--- a/src/experts/resources.php
+++ b/src/experts/resources.php
@@ -138,6 +138,16 @@ return call_user_func( function() {
 			),
 		),
 
+		'jquery.valueview.experts.UnDeserializableValue' => $moduleTemplate + array(
+			'scripts' => array(
+				'UnDeserializableValue.js'
+			),
+			'dependencies' => array(
+				'jquery.valueview.experts',
+				'jquery.valueview.Expert',
+			)
+		),
+
 		'jquery.valueview.experts.UnsupportedValue' => $moduleTemplate + array(
 			'scripts' => array(
 				'UnsupportedValue.js',

--- a/tests/src/experts/UnDeserializableValueTests.js
+++ b/tests/src/experts/UnDeserializableValueTests.js
@@ -1,0 +1,16 @@
+/**
+ * @licence GNU GPL v2+
+ * @author Katie Filbert < aude.wiki@gmail.com >
+ */
+ ( function( QUnit, valueview ) {
+	'use strict';
+
+	var testExpert = valueview.tests.testExpert;
+
+	QUnit.module( 'jquery.valueview.experts.UnDeserializableValue' );
+
+	testExpert( {
+		expertConstructor: valueview.experts.UnDeserializableValue
+	} );
+
+}( QUnit, jQuery.valueview ) );


### PR DESCRIPTION
based on the UnsupportedValue expert, will display the error and allow a user to remove the value.

not super fancy. It would be nicer to display some details of the value or make more attempt to try to parse it or such again. but don't want to make things too "smart" at this point.

this works okay and provided improvement over the current handling.

[Bug: T92975](https://phabricator.wikimedia.org/T92975)