### PR TITLE
Much more obvious listrotator styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Other methods an `Expert` needs to provide:
 * Removed deprecated constant `ValueView_VERSION`, use `VALUEVIEW_VERSION` instead.
 * Removed `jQuery.valueview.disable`, `jQuery.valueview.enable` and `jQuery.valueview.isDisabled`. These function were used to mock native `jQuery.Widget` functionality while adding a full `draw` cycle on top. `jQuery.valueview.draw` does not consider the state anymore.
 
+#### Enhancements
+* Refined `jQuery.ui.listrotator` style to have a more obvious active state.
+
 ### 0.14.5 (2015-06-11)
 * Fixed `jQuery.valueview.ExpertExtender.CalendarHint` test broken due to DataValues JavaScript dependency update.
 

--- a/lib/jquery.ui/jquery.ui.listrotator.css
+++ b/lib/jquery.ui/jquery.ui.listrotator.css
@@ -1,31 +1,43 @@
 /**
  * @licence GNU GPL v2+
  * @author H. Snater < mediawiki@snater.com >
+ * @author Thiemo Mättig
  */
-
 .ui-listrotator {
 	white-space: nowrap;
 	border: none;
 }
 
+/* Override the users "underline" setting, see ResourceLoaderUserCSSPrefsModule::getStyles. */
+.ui-listrotator a {
+	text-decoration: none;
+}
 .ui-listrotator .ui-listrotator-label {
 	background: none;
 	border: none;
 	cursor: pointer;
-	text-decoration: inherit;
+}
+.ui-listrotator .ui-listrotator-label.ui-state-default:hover {
+	color: black;
+	text-decoration: none;
 }
 .ui-listrotator .ui-listrotator-label.ui-state-disabled {
 	cursor: default;
 }
 
+.ui-listrotator .ui-listrotator-auto.ui-state-active,
+.ui-listrotator .ui-listrotator-curr.ui-state-active {
+	background: white;
+}
 .ui-listrotator .ui-state-active .ui-listrotator-label {
 	text-decoration: underline;
-	color: #000000;
+	color: black;
 }
 
 .ui-listrotator .ui-listrotator-auto {
 	float: left;
 	margin-right: 10px;
+	padding: 0 0.4em;
 	border: none;
 	background: none;
 }
@@ -46,7 +58,7 @@
 	text-align: center;
 	padding: 0 5px 0 10px;
 	background: none;
-	border: 1px solid #CCCCCC;
+	border: 1px solid silver;
 }
 .ui-listrotator .ui-listrotator-curr > * {
 	float: left;

--- a/src/ExpertExtender/ExpertExtender.Toggler.css
+++ b/src/ExpertExtender/ExpertExtender.Toggler.css
@@ -3,6 +3,6 @@
 	background: none;
 	margin-top: 0.5em;
 	padding-top: 0.5em;
-	border-top: 1px dashed #CCC;
+	border-top: 1px dashed silver;
 	width: 100%;
 }


### PR DESCRIPTION
This fixes an actual bug: Underlines are used as an indicator. But when the user has it's underline option set, **everything** is underlined.

I'm also adding a white background color to the currently active element to make it much more obvious when "auto" is active or not.

I'm also adding a tiny hover effect to make it more obvious that these are interactive elements, not just labels.

Also changing colors to "silver" because this is what core usually uses.

[Bug: T96685](https://phabricator.wikimedia.org/T96685)