### PR TITLE
Switch commonssuggester to https

### DIFF
--- a/lib/jquery.ui/jquery.ui.commonssuggester.js
+++ b/lib/jquery.ui/jquery.ui.commonssuggester.js
@@ -36,7 +36,7 @@
 				var deferred = $.Deferred();
 
 				$.ajax( {
-					url: location.protocol + '//commons.wikimedia.org/w/api.php',
+					url: 'https://commons.wikimedia.org/w/api.php',
 					dataType: 'jsonp',
 					data: {
 						search: term,

--- a/lib/jquery.ui/jquery.ui.suggester.js
+++ b/lib/jquery.ui/jquery.ui.suggester.js
@@ -16,7 +16,7 @@
  *             var deferred = $.Deferred();
  *
  *             $.ajax( {
- *                 url: location.protocol + '//commons.wikimedia.org/w/api.php',
+ *                 url: 'https://commons.wikimedia.org/w/api.php',
  *                 dataType: 'jsonp',
  *                 data: {
  *                 search: term,


### PR DESCRIPTION
All Wikimedia wikis are now https only. This change saves a redirect, minimizing traffic.