### PR TITLE
Fix minor issues in UnitSelector and related

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ Other methods an `Expert` needs to provide:
 
 ## Release notes
 
+### 0.15.1 (2015-08-20)
+
+#### Enhancements
+* `jQuery.valueview.experts.QuantityInput` also submits the `unit` option if it's null.
+
+#### Bugfixes
+* `jQuery.ui.unitsuggester` now queries the `wbsearchentities` API for a specific language.
+* Fixed `jQuery.valueview.ExpertExtender.UnitSelector.destroy`.
+
 ### 0.15.0 (2015-08-19)
 
 #### Breaking changes

--- a/ValueView.php
+++ b/ValueView.php
@@ -5,7 +5,7 @@ if ( defined( 'VALUEVIEW_VERSION' ) ) {
 	return 1;
 }
 
-define( 'VALUEVIEW_VERSION', '0.15.0' );
+define( 'VALUEVIEW_VERSION', '0.15.1' );
 
 // Include the composer autoloader if it is present.
 if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {

--- a/lib/jquery.ui/jquery.ui.unitsuggester.js
+++ b/lib/jquery.ui/jquery.ui.unitsuggester.js
@@ -151,6 +151,7 @@ $.widget( 'wikibase.unitsuggester', PARENT, {
 			search: term,
 			format: 'json',
 			language: this.options.language,
+			uselang: this.options.language,
 			type: 'item'
 		};
 	},

--- a/src/ExpertExtender/ExpertExtender.UnitSelector.js
+++ b/src/ExpertExtender/ExpertExtender.UnitSelector.js
@@ -98,10 +98,11 @@
 		 * Callback for the `destroy` `ExpertExtender` event.
 		 */
 		destroy: function() {
-			this._getUpstreamValue = null;
-			this.$selector = null;
 			this._messageProvider = null;
+			this._getUpstreamValue = null;
 			this._onValueChange = null;
+			this._options = null;
+			this.$selector = null;
 		},
 
 		/**

--- a/src/experts/QuantityInput.js
+++ b/src/experts/QuantityInput.js
@@ -48,16 +48,9 @@
 		 * @inheritdoc
 		 */
 		valueCharacteristics: function() {
-			var options = {};
-
-			if( this._unitSelector ) {
-				var unit = this._unitSelector.getConceptUri();
-				if( unit ) {
-					options.unit = unit;
-				}
-			}
-
-			return options;
+			return {
+				unit: this._unitSelector && this._unitSelector.getConceptUri() || null
+			};
 		},
 
 		/**


### PR DESCRIPTION
This should fix all issues in https://integration.wikimedia.org/ci/job/mwext-Wikibase-qunit/12702/console.
* The only real bug is the missing line in `destroy`.
* The `uselang` parameter fixes an edge case, see [T109584](https://phabricator.wikimedia.org/T109584).
* The `unit` option can also be fixed by changing the test, but we decided it's better to always submit the option, even if it's `null`.