### PR TITLE
Add vocabularyLookupApiUrl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ Other methods an `Expert` needs to provide:
 
 ## Release notes
 
+### 0.15.2 (2015-08-27)
+
+#### Enhancements
+* `jQuery.valueview.experts.QuantityInput` explicitely asks `QuantityFormatter` to not apply rounding and units.
+* `jQuery.valueview.valueview` passes a `vocabularyLookupApiUrl` option to all experts.
+* `jQuery.valueview.experts.QuantityInput` and `jQuery.valueview.ExpertExtender.UnitSelector` now pass a `vocabularyLookupApiUrl` option to `jQuery.ui.unitsuggester`.
+* `jQuery.ui.unitsuggester` uses the `concepturi` from `wbsearchentities` results, if available.
+
 ### 0.15.1 (2015-08-20)
 
 #### Enhancements

--- a/ValueView.php
+++ b/ValueView.php
@@ -5,7 +5,7 @@ if ( defined( 'VALUEVIEW_VERSION' ) ) {
 	return 1;
 }
 
-define( 'VALUEVIEW_VERSION', '0.15.1' );
+define( 'VALUEVIEW_VERSION', '0.15.2' );
 
 // Include the composer autoloader if it is present.
 if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {

--- a/lib/jquery.ui/jquery.ui.unitsuggester.js
+++ b/lib/jquery.ui/jquery.ui.unitsuggester.js
@@ -296,7 +296,6 @@ $.widget( 'wikibase.unitsuggester', PARENT, {
 	 * Returns the URL of the selected entity. URLs pointing to items on wikidata.org are normalized
 	 * to their canonical concept URI, e.g. https://wikidata.org/wiki/Q650 is returned as
 	 * http://www.wikidata.org/entity/Q650.
-	 * @fixme Teach wbsearchentities to return concept URIs, then remove this normalization.
 	 * @return {string|null}
 	 */
 	getSelectedConceptUri: function() {

--- a/lib/jquery.ui/jquery.ui.unitsuggester.js
+++ b/lib/jquery.ui/jquery.ui.unitsuggester.js
@@ -20,8 +20,8 @@ $.widget( 'wikibase.unitsuggester', PARENT, {
 	 * @property {Object}
 	 */
 	options: {
-		url: 'https://www.wikidata.org/w/api.php',
 		language: null,
+		vocabularyLookupApiUrl: null,
 		timeout: 8000
 	},
 
@@ -171,7 +171,7 @@ $.widget( 'wikibase.unitsuggester', PARENT, {
 				data = self._getData( term );
 
 			$.ajax( {
-				url: self.options.url,
+				url: self.options.vocabularyLookupApiUrl || 'https://www.wikidata.org/w/api.php',
 				dataType: 'jsonp',
 				data: data,
 				timeout: self.options.timeout
@@ -293,9 +293,11 @@ $.widget( 'wikibase.unitsuggester', PARENT, {
 	},
 
 	/**
-	 * Returns concept URI for an item for example:
-	 * http://www.wikidata.org/entity/Q650
-	 * @return {string}
+	 * Returns the URL of the selected entity. URLs pointing to items on wikidata.org are normalized
+	 * to their canonical concept URI, e.g. https://wikidata.org/wiki/Q650 is returned as
+	 * http://www.wikidata.org/entity/Q650.
+	 * @fixme Teach wbsearchentities to return concept URIs, then remove this normalization.
+	 * @return {string|null}
 	 */
 	getSelectedConceptUri: function() {
 		return this._selectedUrl && this._selectedUrl.replace(

--- a/src/ExpertExtender/ExpertExtender.UnitSelector.js
+++ b/src/ExpertExtender/ExpertExtender.UnitSelector.js
@@ -14,7 +14,8 @@
 	 * @param {Function} getUpstreamValue
 	 * @param {Function} onValueChange
 	 * @param {Object} [options={}]
-	 * @param {string} [options.language=null]
+	 * @param {string|null} [options.language=null]
+	 * @param {string|null} [options.vocabularyLookupApiUrl=null]
 	 */
 	ExpertExtender.UnitSelector = function(
 		messageProvider,
@@ -73,6 +74,7 @@
 			);
 			this.$selector.unitsuggester( {
 				language: this._options.language || null,
+				vocabularyLookupApiUrl: this._options.vocabularyLookupApiUrl || null,
 				change: this._onValueChange
 			} );
 			$extender

--- a/src/experts/QuantityInput.js
+++ b/src/experts/QuantityInput.js
@@ -25,7 +25,8 @@
 				self._viewNotifier.notify( 'change' );
 			},
 			{
-				language: self._options.language
+				language: self._options.language || null,
+				vocabularyLookupApiUrl: self._options.vocabularyLookupApiUrl || null
 			}
 		);
 

--- a/src/jquery.valueview.valueview.js
+++ b/src/jquery.valueview.valueview.js
@@ -47,6 +47,7 @@ function expertProxy( fnName ) {
  * @param {string} options.language
  *        Language code of the language the `valueview` shall interact with parsers and
  *        formatters.
+ * @param {string|null} [options.vocabularyLookupApiUrl=null]
  * @param {string|null} [options.dataTypeId=null]
  *        If set, an expert (`jQuery.valueview.Expert`), a parser (`valueParsers.ValueParser`) and a
  *        formatter (`valueFormatters.ValueFormatter`) will be determined from the provided
@@ -182,6 +183,7 @@ $.widget( 'valueview.valueview', PARENT, {
 		dataValueType: null,
 		value: null,
 		language: null,
+		vocabularyLookupApiUrl: null,
 		autoStartEditing: false,
 		parseDelay: 300,
 		messageProvider: null,
@@ -556,6 +558,7 @@ $.widget( 'valueview.valueview', PARENT, {
 				this.viewNotifier(),
 				{
 					language: this.options.language,
+					vocabularyLookupApiUrl: this.options.vocabularyLookupApiUrl || null,
 					contentLanguages: this.options.contentLanguages,
 					messageProvider: this.options.messageProvider
 				}


### PR DESCRIPTION
Required for https://gerrit.wikimedia.org/r/#/c/233948/.

Note that this does not fix the issue we want to fix. The wbsearchentities API still does **not** return concept URIs. The unitsuggester needs to ignore the URL and construct it's own concept URI from the entity IDs returned. But to do this it needs just an *other* setting: `conceptBaseUri`.

At this point it seems easier to pass in the while repo config array... :-(