### PR TITLE
Make Experts aware of the output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Other methods an `Expert` needs to provide:
 ### 0.15.2 (2015-08-27)
 
 #### Enhancements
-* `jQuery.valueview.experts.QuantityInput` explicitely asks `QuantityFormatter` to not apply rounding and units.
+* `jQuery.valueview.expert.valueCharacteristics` gets the output format passed in.
+* `jQuery.valueview.experts.QuantityInput` explicitely asks `QuantityFormatter` to not apply rounding and units in plain text format.
 * `jQuery.valueview.valueview` passes a `vocabularyLookupApiUrl` option to all experts.
 * `jQuery.valueview.experts.QuantityInput` and `jQuery.valueview.ExpertExtender.UnitSelector` now pass a `vocabularyLookupApiUrl` option to `jQuery.ui.unitsuggester`.
 * `jQuery.ui.unitsuggester` uses the `concepturi` from `wbsearchentities` results, if available.
@@ -291,7 +292,7 @@ Other methods an `Expert` needs to provide:
 * Make the minimal term length of the suggester configurable.
 * Add resource loader dependencies for jquery.ui.suggester, fixing bug 66268 and bug 66257.
 
-### 0.6 (2014-06-04)
+### 0.6.0 (2014-06-04)
 
 * Re-created jQuery.ui.suggester widget removing dependencies on jQuery.ui.autocomplete and jQuery.ui.menu
 * Implemented jQuery.util.highlightMatchingCharacters
@@ -309,7 +310,7 @@ Other methods an `Expert` needs to provide:
 * Change TimeInput::draw() to update the rotators' values if they are in auto mode
 * Change GlobeCoordinateInput::draw() to update the precision rotator value if it is in auto mode
 
-### 0.5 (2014-03-28)
+### 0.5.0 (2014-03-28)
 
 * Renamed jQuery.valueView.ExpertFactory to jQuery.valueView.ExpertStore.
 * Renamed jQuery.valueView option "expertProvider" to "expertStore".
@@ -332,7 +333,7 @@ Other methods an `Expert` needs to provide:
 
 * Updated DataValues JavaScript dependency to version 0.4.
 
-### 0.4 (2014-03-26)
+### 0.4.0 (2014-03-26)
 
 * Remove trimming from StringValue expert
 * Use ViewState::getFormattedValue for GlobeCoordinate formatting
@@ -357,7 +358,7 @@ Other methods an `Expert` needs to provide:
 * Use ViewState::getFormattedValue for Url formatting
 * Use ViewState::getFormattedValue for GlobeCoordinate formatting
 
-### 0.3 (2014-02-04)
+### 0.3.0 (2014-02-04)
 
 #### Enhancements
 
@@ -383,7 +384,7 @@ Other methods an `Expert` needs to provide:
 * Updated DataValues JavaScript dependency to version 0.3.
 * Renamed jQuery.valueview.preview to jQuery.ui.preview
 
-### 0.2 (2014-01-29)
+### 0.2.0 (2014-01-29)
 
 #### Refactorings
 
@@ -412,7 +413,7 @@ Other methods an `Expert` needs to provide:
 
 * #6 Added util.Notifier
 
-### 0.1 (2013-12-23)
+### 0.1.0 (2013-12-23)
 
 Initial release.
 

--- a/src/experts/QuantityInput.js
+++ b/src/experts/QuantityInput.js
@@ -48,12 +48,17 @@
 		/**
 		 * @inheritdoc
 		 */
-		valueCharacteristics: function() {
-			return {
-				unit: this._unitSelector && this._unitSelector.getConceptUri() || null,
-				applyUnit: false,
-				applyRounding: false
+		valueCharacteristics: function( format ) {
+			var options = {
+				unit: this._unitSelector && this._unitSelector.getConceptUri() || null
 			};
+
+			if( format === 'text/plain' ) {
+				options.applyRounding = false;
+				options.applyUnit = false;
+			}
+
+			return options;
 		},
 
 		/**

--- a/src/jquery.valueview.Expert.js
+++ b/src/jquery.valueview.Expert.js
@@ -243,9 +243,11 @@ jQuery.valueview = jQuery.valueview || {};
 		 *
 		 * This method should allow to be called statically, i. e. without a useful `this` context.
 		 *
+		 * @param {string} [format='text/html'] Typically "text/plain". Implementations should
+		 * fall back to "text/html" when the format is undefined.
 		 * @return {Object}
 		 */
-		valueCharacteristics: function() {
+		valueCharacteristics: function( format ) {
 			return {};
 		},
 

--- a/src/jquery.valueview.valueview.js
+++ b/src/jquery.valueview.valueview.js
@@ -733,7 +733,7 @@ $.widget( 'valueview.valueview', PARENT, {
 			clearTimeout( this._parseTimer );
 		}
 
-		var valueParser = this._instantiateParser( this.valueCharacteristics() );
+		var valueParser = this._instantiateParser( this.valueCharacteristics( 'text/plain' ) );
 
 		self.__lastUpdateValue = rawValue;
 		this._parseTimer = setTimeout( function() {
@@ -860,6 +860,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	_updateTextValue: function() {
 		var self = this,
 			deferred = $.Deferred(),
+			format = 'text/plain',
 			valueFormatter,
 			dataTypeId = this.options.dataTypeId || null,
 			dataValue = this._value;
@@ -870,9 +871,9 @@ $.widget( 'valueview.valueview', PARENT, {
 			return deferred.promise();
 		}
 
-		valueFormatter = this._instantiateFormatter( this.valueCharacteristics() );
+		valueFormatter = this._instantiateFormatter( this.valueCharacteristics( format ) );
 
-		valueFormatter.format( dataValue, dataTypeId, 'text/plain' )
+		valueFormatter.format( dataValue, dataTypeId, format )
 			.done( function( formattedValue, formattedDataValue ) {
 				if( dataValue === formattedDataValue ) {
 					self._textValue = formattedValue;
@@ -992,14 +993,15 @@ $.widget( 'valueview.valueview', PARENT, {
 	/**
 	 * @see jQuery.valueview.Expert.valueCharacteristics
 	 *
+	 * @param {string} [format='text/html']
 	 * @return {Object}
 	 */
-	valueCharacteristics: function() {
+	valueCharacteristics: function( format ) {
 		if( this._expert ) {
-			return this._expert.valueCharacteristics();
+			return this._expert.valueCharacteristics( format );
 		}
 		if( this._expertConstructor ) {
-			return this._expertConstructor.prototype.valueCharacteristics();
+			return this._expertConstructor.prototype.valueCharacteristics( format );
 		}
 		return {};
 	}


### PR DESCRIPTION
The option send to the plain text formatter (in contrast to the HTML formatter) and the options send to the parser should be the same to guarantee a full roundtrip.

[Bug: T110183](https://phabricator.wikimedia.org/T110183)