### PR TITLE
Bugfixes in unitsuggester

### DIFF
--- a/lib/jquery.ui/jquery.ui.unitsuggester.js
+++ b/lib/jquery.ui/jquery.ui.unitsuggester.js
@@ -1,10 +1,10 @@
-( function( $, util ) {
+( function( $ ) {
 	'use strict';
 
 var PARENT = $.ui.suggester;
 
 /**
- * @class jQuery.ui.languagesuggester
+ * @class jQuery.ui.unitsuggester
  * @extends jQuery.ui.suggester
  * @licence GNU GPL v2+
  * @author Thiemo Mättig
@@ -12,8 +12,7 @@ var PARENT = $.ui.suggester;
  *
  * @constructor
  */
-
-$.widget( 'wikibase.unitsuggester', PARENT, {
+$.widget( 'ui.unitsuggester', PARENT, {
 
 	/**
 	 * Options
@@ -306,4 +305,4 @@ $.widget( 'wikibase.unitsuggester', PARENT, {
 	}
 } );
 
-}( jQuery, util ) );
+}( jQuery ) );


### PR DESCRIPTION
I think that all these bug fixes are non-breaking, but I might be wrong. The widget is called in UnitSelectot.js via `this.$selector.unitsuggester()`. The "wikibase" namespace does not matter there.

[Bug: T110675](https://phabricator.wikimedia.org/T110675)