### PR TITLE
Show label instead of URI in UnitSelector

### DIFF
--- a/lib/jquery.ui/jquery.ui.unitsuggester.js
+++ b/lib/jquery.ui/jquery.ui.unitsuggester.js
@@ -51,6 +51,7 @@ $.widget( 'wikibase.unitsuggester', PARENT, {
 	_create: function() {
 		var self = this;
 
+		this._selectedUrl = this.options.defaultSelectedUrl;
 		this._cache = {};
 		this.options.source = this._initDefaultSource();
 

--- a/src/ExpertExtender/ExpertExtender.UnitSelector.js
+++ b/src/ExpertExtender/ExpertExtender.UnitSelector.js
@@ -75,7 +75,8 @@
 			this.$selector.unitsuggester( {
 				language: this._options.language || null,
 				vocabularyLookupApiUrl: this._options.vocabularyLookupApiUrl || null,
-				change: this._onValueChange
+				change: this._onValueChange,
+				defaultSelectedUrl: this._getUpstreamValue().conceptUri
 			} );
 			$extender
 				.append( $( '<span>' ).text( label ) )
@@ -86,7 +87,7 @@
 		 * Callback for the `onInitialShow` `ExpertExtender` event.
 		 */
 		onInitialShow: function() {
-			var value = this._getUpstreamValue();
+			var value = this._getUpstreamValue().label;
 			if( value === '1' ||
 				value === 'http://qudt.org/vocab/unit#Unitless' ||
 				/^(?:https?:)?\/\/(?:www\.)?wikidata\.org\/\w+\/Q199$/i.test( value )

--- a/src/experts/QuantityInput.js
+++ b/src/experts/QuantityInput.js
@@ -1,4 +1,4 @@
-( function( vv, UnitSelector ) {
+( function( $, vv, UnitSelector ) {
 	'use strict';
 
 	var PARENT = vv.experts.StringValue;
@@ -18,8 +18,14 @@
 		this._unitSelector = new UnitSelector(
 			this._messageProvider,
 			function() {
-				var value = self.viewState().value();
-				return value && value.getUnit();
+				var value = self.viewState().value(),
+					unit = value && value.getUnit(),
+					formattedValue = self.viewState().getFormattedValue(),
+					$unit = $( '<div>' ).html( formattedValue ).find( '.wb-unit' ).first();
+				return {
+					conceptUri: unit,
+					label: $unit.text() || unit
+				};
 			},
 			function() {
 				self._viewNotifier.notify( 'change' );
@@ -71,4 +77,4 @@
 		}
 	} );
 
-}( jQuery.valueview, jQuery.valueview.ExpertExtender.UnitSelector ) );
+}( jQuery, jQuery.valueview, jQuery.valueview.ExpertExtender.UnitSelector ) );


### PR DESCRIPTION
This requires the backend change in https://github.com/DataValues/Number/pull/41: the formatter must output a node with `class="wb-unit"`.

[Bug: T110675](https://phabricator.wikimedia.org/T110675)