### PR TITLE
Enable JSCS rule requireSpaceAfterKeywords

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -78,15 +78,16 @@
 	// ----
 	// Own rules
 
-	"disallowSpaceAfterKeywords": [
-		"catch",
-		"for",
-		"if",
-		"switch",
-		"while"
-	],
 	"requireSpaceAfterKeywords": [
-		"else"
+		"if",
+		"else",
+		"for",
+		"while",
+		"do",
+		"switch",
+		"return",
+		"try",
+		"catch"
 	],
 
 	"excludeFiles": [ "node_modules/**", "vendor/**" ]

--- a/lib/jquery.event/jquery.event.special.eachchange.js
+++ b/lib/jquery.event/jquery.event.special.eachchange.js
@@ -50,7 +50,7 @@
 				eventId = EVENT_ID + handleObj.namespace,
 				eventNameString = assignNamespace( inputEvent, eventId );
 
-			if( !eventData ) {
+			if ( !eventData ) {
 				eventData = { handlers: [], prevVal: getValue( $elem ) };
 				$( document ).on( eventNameString, function( event ) {
 					eventData = $.data( $elem[0], eventId );
@@ -68,7 +68,7 @@
 			$elem.on( eventNameString, function( event ) {
 				eventData = $.data( this, eventId );
 
-				if( !eventData ) {
+				if ( !eventData ) {
 					// Event has been removed but event handler is in the loop.
 					return;
 				}
@@ -95,7 +95,7 @@
 				prevVal = getValue( $( this ) );
 
 			$.each( $.data( this ), function( eventId, eventData ) {
-				if( eventId.indexOf( EVENT_ID ) === 0 ) {
+				if ( eventId.indexOf( EVENT_ID ) === 0 ) {
 					eventData.prevVal = prevVal;
 					$.data( self, eventId, eventData );
 				}
@@ -106,9 +106,9 @@
 		},
 
 		handle: function( event, data ) {
-			if( event.namespace !== '' ) {
+			if ( event.namespace !== '' ) {
 				var eventData = $.data( this, EVENT_ID + event.namespace );
-				if( eventData ) {
+				if ( eventData ) {
 					event.handleObj.handler.call( this, event, eventData.prevVal );
 				}
 
@@ -116,15 +116,15 @@
 				var self = this;
 
 				$.each( $.data( this ), function( eventId, eventData ) {
-					if( eventId.indexOf( EVENT_ID ) !== 0 ) {
+					if ( eventId.indexOf( EVENT_ID ) !== 0 ) {
 						// Event is not an eachchange event.
 						return true;
 					}
 
 					var handlers = $.data( self, eventId ).handlers;
 
-					for( var i = 0; i < handlers.length; i++ ) {
-						if( !alreadyTriggered( eventId, i ) ) {
+					for ( var i = 0; i < handlers.length; i++ ) {
+						if ( !alreadyTriggered( eventId, i ) ) {
 							handlers[i].call( self, event, eventData.prevVal );
 
 							triggeredHandlers.push( {
@@ -153,8 +153,8 @@
 	 *        event id.
 	 */
 	function alreadyTriggered( eventId, index ) {
-		for( var i = 0; i < triggeredHandlers.length; i++ ) {
-			if( eventId === triggeredHandlers[i].id && index === triggeredHandlers[i].index ) {
+		for ( var i = 0; i < triggeredHandlers.length; i++ ) {
+			if ( eventId === triggeredHandlers[i].id && index === triggeredHandlers[i].index ) {
 				return true;
 			}
 		}
@@ -174,7 +174,7 @@
 		// jQuery mechanism trying to retrieve the value.
 		try {
 			return $elem.val();
-		} catch( e ) {
+		} catch ( e ) {
 			return null;
 		}
 	}
@@ -191,7 +191,7 @@
 		var names = eventNames.split( ' ' ),
 			namespacedNames = [];
 
-		for( var i = 0; i < names.length; i++ ) {
+		for ( var i = 0; i < names.length; i++ ) {
 			namespacedNames.push( names[i] + '.' + namespace );
 		}
 
@@ -208,7 +208,7 @@
 	function getInputEvent() {
 		// IE (at least <= version 9) does not trigger input event when pressing backspace
 		// (version <= 8 does not support input event at all anyway)
-		if( $.client.profile().name === 'msie' && $.client.profile().versionNumber >= 9 ) {
+		if ( $.client.profile().name === 'msie' && $.client.profile().versionNumber >= 9 ) {
 			return 'input keyup';
 		}
 

--- a/lib/jquery.ui/jquery.ui.commonssuggester.js
+++ b/lib/jquery.ui/jquery.ui.commonssuggester.js
@@ -19,7 +19,7 @@
 		 * @protected
 		 */
 		_create: function() {
-			if( !this.options.source ) {
+			if ( !this.options.source ) {
 				this.options.source = this._initDefaultSource();
 			}
 			$.ui.suggester.prototype._create.call( this );
@@ -66,7 +66,7 @@
 
 			var label = suggestion;
 
-			if( requestTerm ) {
+			if ( requestTerm ) {
 				label = util.highlightSubstring( requestTerm, suggestion );
 			}
 

--- a/lib/jquery.ui/jquery.ui.inputextender.js
+++ b/lib/jquery.ui/jquery.ui.inputextender.js
@@ -24,13 +24,13 @@ var inputExtendersWithVisibleExtension = ( function() {
 	return {
 		add: function( inputExtenderInstance ) {
 			var index = $.inArray( inputExtenderInstance, inputExtenders );
-			if( index < 0 ) {
+			if ( index < 0 ) {
 				inputExtenders.push( inputExtenderInstance );
 			}
 		},
 		remove: function( inputExtenderInstance ) {
 			var index = $.inArray( inputExtenderInstance, inputExtenders );
-			if( index > -1 ) {
+			if ( index > -1 ) {
 				inputExtenders.splice( index, 1 );
 			}
 		},
@@ -170,7 +170,7 @@ $.widget( 'ui.inputextender', {
 		//  leave enough time to tab again, by mouse the extension can be shown immediately.
 		this.element
 		.on( 'focus.' + this.widgetName, function( event ) {
-			if( !self.options.hideWhenInputEmpty || self.element.val() !== '' ) {
+			if ( !self.options.hideWhenInputEmpty || self.element.val() !== '' ) {
 				clearTimeout( self._animationTimeout );
 				self._animationTimeout = setTimeout( function() {
 					self.showExtension();
@@ -178,7 +178,7 @@ $.widget( 'ui.inputextender', {
 			}
 		} )
 		.on( 'blur.' + this.widgetName, function( event ) {
-			if( self.__extensionFocused ) {
+			if ( self.__extensionFocused ) {
 				delete self.__extensionFocused;
 				return;
 			}
@@ -188,26 +188,26 @@ $.widget( 'ui.inputextender', {
 			}, 250 ); // TODO: Fixed values can't be changed nor turned off
 		} )
 		.on( 'keydown.' + this.widgetName, function( event ) {
-			if( event.keyCode === $.ui.keyCode.ESCAPE ) {
+			if ( event.keyCode === $.ui.keyCode.ESCAPE ) {
 				self.hideExtension();
-			} else if(
-				self.extensionIsVisible()
-				&& event.keyCode === $.ui.keyCode.TAB && !event.shiftKey
+			} else if ( self.extensionIsVisible()
+				&& event.keyCode === $.ui.keyCode.TAB
+				&& !event.shiftKey
 			) {
 				event.preventDefault();
 				// When tabbing out of the input element, focus the first focusable element
 				// within the extension.
 				var $focusable = self._$extension.find( ':focusable' );
-				if( $focusable.length ) {
+				if ( $focusable.length ) {
 					$focusable.first().focus();
 					clearTimeout( self._animationTimeout );
 				}
 			}
 		} );
 
-		if( this.options.hideWhenInputEmpty ) {
+		if ( this.options.hideWhenInputEmpty ) {
 			this.element.on( 'eachchange', function( event, oldValue ) {
-				if( self.element.val() === '' ) {
+				if ( self.element.val() === '' ) {
 					self.hideExtension();
 				} else {
 					self.showExtension();
@@ -226,14 +226,14 @@ $.widget( 'ui.inputextender', {
 
 				// Hide the extension neither it nor the corresponding input element is
 				// clicked:
-				if( !$target.closest( widget.element.add( widget._$extension ) ).length ) {
+				if ( !$target.closest( widget.element.add( widget._$extension ) ).length ) {
 					widget.hideExtension();
 				}
 
 			} );
 		} );
 
-		if( this.element.is( ':focus' ) ) {
+		if ( this.element.is( ':focus' ) ) {
 			this.showExtension();
 		} else {
 			this.draw();
@@ -244,12 +244,12 @@ $.widget( 'ui.inputextender', {
 	 * @see jQuery.Widget.destroy
 	 */
 	destroy: function() {
-		if( this.extensionIsActive() ) {
+		if ( this.extensionIsActive() ) {
 			// Hide extension the official way, make sure events getting triggered.
 			this.hideExtension();
 		}
 
-		if( this._$extension ) {
+		if ( this._$extension ) {
 			// Stop any ongoing extension hiding animation immediately, jump to its end.
 			this._$extension.stop( false, true );
 			this._$extension.remove();
@@ -265,7 +265,7 @@ $.widget( 'ui.inputextender', {
 	 * @param {Function} [callback] Invoked as soon as the extension's show animation is done.
 	 */
 	showExtension: function( callback ) {
-		if( !this._isExtended ) {
+		if ( !this._isExtended ) {
 			this._isExtended = true;
 			this.draw( callback );
 			this._trigger( 'aftertoggle' );
@@ -278,7 +278,7 @@ $.widget( 'ui.inputextender', {
 	 * @param {Function} [callback] Invoked as soon as the extension's hide animation is done.
 	 */
 	hideExtension: function( callback ) {
-		if( this._isExtended ) {
+		if ( this._isExtended ) {
 			this._isExtended = false;
 			this.draw( callback );
 			this._trigger( 'aftertoggle' );
@@ -311,7 +311,7 @@ $.widget( 'ui.inputextender', {
 	 * @return {boolean}
 	 */
 	extensionIsVisible: function() {
-		if( !this._$extension ) {
+		if ( !this._$extension ) {
 			return false;
 		}
 		return this._extensionIsVisible;
@@ -338,16 +338,16 @@ $.widget( 'ui.inputextender', {
 		var extensionIsVisible = this.extensionIsVisible(),
 			$extension = this._$extension;
 
-		if( !extensionIsVisible && !this._isExtended ) {
+		if ( !extensionIsVisible && !this._isExtended ) {
 			// Extension not displayed and not supposed to be displayed.
 			return;
 		}
 
-		if( !$extension ) {
+		if ( !$extension ) {
 			this._$extension = $extension = this._buildExtension();
 			$extension.appendTo( $( 'body' ) );
 
-			if( $.isFunction( this.options.initCallback ) ) {
+			if ( $.isFunction( this.options.initCallback ) ) {
 				$extension.show();
 				this.options.initCallback.call( this, $extension );
 				$extension.hide();
@@ -355,7 +355,7 @@ $.widget( 'ui.inputextender', {
 		}
 
 		// Element needs to be visible to use jquery.ui.position.
-		if( !extensionIsVisible ) {
+		if ( !extensionIsVisible ) {
 			$extension.show();
 			this._reposition();
 			$extension.hide();
@@ -363,9 +363,9 @@ $.widget( 'ui.inputextender', {
 			this._reposition();
 		}
 
-		if( extensionIsVisible !== this._isExtended ) {
+		if ( extensionIsVisible !== this._isExtended ) {
 			// Represent actual expansion status:
-			if( this._isExtended ) {
+			if ( this._isExtended ) {
 				this._drawExtensionExpansion( callback );
 			} else {
 				this._drawExtensionRemoval( callback );
@@ -385,7 +385,7 @@ $.widget( 'ui.inputextender', {
 		// When blurring the browser viewport and an re-focusing, Chrome is firing the "focus"
 		// event twice. jQuery fadeIn sets the opacity to 0 for the first fadeIn but does not
 		// pick up the value when triggering fadeIn the second time.
-		if( this._$extension.css( 'opacity' ) === '0' ) {
+		if ( this._$extension.css( 'opacity' ) === '0' ) {
 			this._$extension.css( 'opacity', '1' );
 		}
 
@@ -395,7 +395,7 @@ $.widget( 'ui.inputextender', {
 			{
 				duration: 150, // TODO: Fixed values can't be changed nor turned off
 				complete: function() {
-					if( $.isFunction( callback ) ) {
+					if ( $.isFunction( callback ) ) {
 						callback();
 					}
 				}
@@ -423,7 +423,7 @@ $.widget( 'ui.inputextender', {
 				duration: 150, // TODO: Fixed values can't be changed nor turned off
 				complete: function() {
 					inputExtendersWithVisibleExtension.remove( self );
-					if( $.isFunction( callback ) ) {
+					if ( $.isFunction( callback ) ) {
 						callback();
 					}
 				}
@@ -444,7 +444,7 @@ $.widget( 'ui.inputextender', {
 			hOffsetChanged = this._offset && ( offset.left !== this._offset.left
 				|| IS_RTL && offset.right !== this._offset.right );
 
-		if( this._offset && ( vOffsetChanged || hOffsetChanged ) ) {
+		if ( this._offset && ( vOffsetChanged || hOffsetChanged ) ) {
 			return; // Position has not changed.
 		}
 
@@ -454,7 +454,7 @@ $.widget( 'ui.inputextender', {
 		 * @return {string}
 		 */
 		function evaluateRtl( string ) {
-			if( IS_RTL ) {
+			if ( IS_RTL ) {
 				string = ( string.indexOf( 'left' ) !== -1 )
 					? string.replace( /left/ig, 'right' )
 					: string.replace( /right/ig, 'left' );
@@ -493,7 +493,7 @@ $.widget( 'ui.inputextender', {
 		$extension
 		.append( $closeButton )
 		.on( 'mousedown.' + this.widgetName, function( event ) {
-			if( !$( event.target ).closest( $closeButton ).length ) {
+			if ( !$( event.target ).closest( $closeButton ).length ) {
 				self.__extensionFocused = true;
 				clearTimeout( self._animationTimeout );
 				self.showExtension();
@@ -505,20 +505,20 @@ $.widget( 'ui.inputextender', {
 		} )
 		.on( 'keydown.' + this.widgetName, function( event ) {
 			// Take care of tabbing out of the extension again:
-			if( event.keyCode === $.ui.keyCode.TAB ) {
+			if ( event.keyCode === $.ui.keyCode.TAB ) {
 				var $focusable = self._$extension.find( ':focusable' );
 
-				if( $focusable.first().is( event.target ) && event.shiftKey ) {
+				if ( $focusable.first().is( event.target ) && event.shiftKey ) {
 					event.preventDefault();
 					// Tab back to the input element:
 					self.element.focus();
-				} else if( $focusable.last().is( event.target ) && !event.shiftKey ) {
+				} else if ( $focusable.last().is( event.target ) && !event.shiftKey ) {
 					event.preventDefault();
 					// Tabbing forward out of the extension: Focus the next focusable element
 					// after the input element.
 					$focusable = $( ':focusable' );
 					$focusable.each( function( i, node ) {
-						if( self.element.is( node ) ) {
+						if ( self.element.is( node ) ) {
 							self.hideExtension();
 							$focusable[ ( i + 1 >= $focusable.length ) ? 0 : i + 1 ].focus();
 						}

--- a/lib/jquery.ui/jquery.ui.languagesuggester.js
+++ b/lib/jquery.ui/jquery.ui.languagesuggester.js
@@ -57,11 +57,11 @@ $.widget( 'ui.languagesuggester', PARENT, {
 		deferred.resolve( $.grep( source, function( item ) {
 			return matcher.test( item.code ) || matcher.test( item.label );
 		} ).sort( function( a, b ) {
-			for( var i = 0; i < promoters.length; i++ ) {
+			for ( var i = 0; i < promoters.length; i++ ) {
 				var promoterA = promoters[i]( a ),
 					promoterB = promoters[i]( b );
 
-				if( promoterA !== promoterB ) {
+				if ( promoterA !== promoterB ) {
 					return promoterB - promoterA;
 				}
 			}

--- a/lib/jquery.ui/jquery.ui.listrotator.js
+++ b/lib/jquery.ui/jquery.ui.listrotator.js
@@ -187,11 +187,11 @@ $.widget( 'ui.listrotator', {
 			iconClasses = ['ui-icon ui-icon-triangle-1-w', 'ui-icon ui-icon-triangle-1-e'];
 
 		// Flip triangle arrows in rtl context:
-		if( this._isRtl() ) {
+		if ( this._isRtl() ) {
 			iconClasses.reverse();
 		}
 
-		if( this.options.values.length === 0 ) {
+		if ( this.options.values.length === 0 ) {
 			throw new Error( 'List of values required to initialize list rotator.' );
 		}
 
@@ -199,7 +199,7 @@ $.widget( 'ui.listrotator', {
 
 		// Construct "auto" link:
 		this.$auto = this._createSection( 'auto', function( event ) {
-			if( self.autoActive() ) {
+			if ( self.autoActive() ) {
 				return;
 			}
 			self.activate( self.$auto );
@@ -210,7 +210,7 @@ $.widget( 'ui.listrotator', {
 
 		// Construct the basic sections:
 		this.$curr = this._createSection( 'curr', function( event ) {
-			if( !self.$menu.is( ':visible' ) ) {
+			if ( !self.$menu.is( ':visible' ) ) {
 				self._showMenu();
 			} else {
 				self._hideMenu();
@@ -228,7 +228,7 @@ $.widget( 'ui.listrotator', {
 		} )
 		.append( $( '<span/>' ).addClass( iconClasses[1] ) );
 
-		if( this.$auto ) {
+		if ( this.$auto ) {
 			this.element.append( this.$auto );
 		}
 		this.element.append( this.$prev ).append( this.$curr ).append( this.$next );
@@ -246,7 +246,7 @@ $.widget( 'ui.listrotator', {
 
 				// Hide the menu if it is neither the "current" node nor the menu's node that
 				// has been clicked.
-				if( !$target.closest( listrotator.$curr.add( listrotator.$menu ) ).length ) {
+				if ( !$target.closest( listrotator.$curr.add( listrotator.$menu ) ).length ) {
 					listrotator.$menu.hide();
 				}
 
@@ -256,7 +256,7 @@ $.widget( 'ui.listrotator', {
 		// Focus on first element:
 		this.value( this.options.values[0].value );
 
-		if( !this.options.deferInit ) {
+		if ( !this.options.deferInit ) {
 			this.initWidths();
 		}
 
@@ -267,7 +267,7 @@ $.widget( 'ui.listrotator', {
 	 */
 	destroy: function() {
 		var menu = this.$menu.data( 'menu' );
-		if( menu ) {
+		if ( menu ) {
 			menu.destroy();
 		}
 
@@ -282,7 +282,7 @@ $.widget( 'ui.listrotator', {
 		$.Widget.prototype.destroy.call( this );
 
 		// Remove event attached to the html node if no instances of the widget exist anymore:
-		if( $( ':' + this.widgetBaseClass ).length === 0 ) {
+		if ( $( ':' + this.widgetBaseClass ).length === 0 ) {
 			$( 'html' ).off( '.' + this.widgetBaseClass );
 		}
 	},
@@ -308,13 +308,13 @@ $.widget( 'ui.listrotator', {
 			labels
 		);
 		$.each( stringWidths, function( i, width ) {
-			if( width > currMaxWidth ) {
+			if ( width > currMaxWidth ) {
 				currMaxWidth = width;
 			}
-			if( i < stringWidths.length && width > prevMaxWidth ) {
+			if ( i < stringWidths.length && width > prevMaxWidth ) {
 				prevMaxWidth = width;
 			}
-			if( i > 0 && width > nextMaxWidth ) {
+			if ( i > 0 && width > nextMaxWidth ) {
 				nextMaxWidth = width;
 			}
 		} );
@@ -346,7 +346,7 @@ $.widget( 'ui.listrotator', {
 		.addClass( this.widgetBaseClass + '-' + classSuffix )
 		.on( 'click.' + this.widgetBaseClass, function( event ) {
 			event.preventDefault();
-			if( !$( this ).hasClass( 'ui-state-disabled' ) ) {
+			if ( !$( this ).hasClass( 'ui-state-disabled' ) ) {
 				clickCallback( event );
 			}
 		} )
@@ -406,7 +406,7 @@ $.widget( 'ui.listrotator', {
 	 */
 	value: function( value ) {
 		// Get the current value:
-		if( value === undefined || value === this.$curr.data( 'value' ) ) {
+		if ( value === undefined || value === this.$curr.data( 'value' ) ) {
 			return this.$curr.data( 'value' );
 		}
 
@@ -418,7 +418,7 @@ $.widget( 'ui.listrotator', {
 
 		// Retrieve the index of the new value within the list of predefined values:
 		$.each( values, function( i, v ) {
-			if( value === v.value ) {
+			if ( value === v.value ) {
 				index = i;
 				return false;
 			}
@@ -430,14 +430,14 @@ $.widget( 'ui.listrotator', {
 		.children( '.' + this.widgetBaseClass + '-label' )
 		.text( values[index].label );
 
-		if( index > 0 ) {
+		if ( index > 0 ) {
 			this.$prev
 			.data( 'value', values[index - 1].value )
 			.children( '.' + this.widgetBaseClass + '-label' )
 			.text( values[index - 1].label );
 		}
 
-		if( index < values.length - 1 ) {
+		if ( index < values.length - 1 ) {
 			this.$next
 			.data( 'value', values[index + 1].value )
 			.children( '.' + this.widgetBaseClass + '-label' )
@@ -453,7 +453,7 @@ $.widget( 'ui.listrotator', {
 		this.$menu.children( 'li' ).each( function( i, li ) {
 			var $li = $( li );
 			$li.removeClass( 'ui-state-active' );
-			if( $li.data( 'value' ) === value ) {
+			if ( $li.data( 'value' ) === value ) {
 				$li.addClass( 'ui-state-active' );
 			}
 		} );
@@ -470,7 +470,7 @@ $.widget( 'ui.listrotator', {
 	_setValue: function( newValue ) {
 		var self = this;
 
-		if( this.$curr.data( 'value' ) === newValue ) {
+		if ( this.$curr.data( 'value' ) === newValue ) {
 			// Value is set already.
 			return;
 		}
@@ -504,8 +504,7 @@ $.widget( 'ui.listrotator', {
 	 * @param {string} newValue
 	 */
 	rotate: function( newValue ) {
-		if(
-			newValue === this._rotatingTo
+		if ( newValue === this._rotatingTo
 			|| !this._rotatingTo && newValue === this.$curr.data( 'value' )
 		) {
 			// Rotation is to the given target is in progress or has been performed already.
@@ -527,20 +526,20 @@ $.widget( 'ui.listrotator', {
 		// Figure out whether rotating to the right or to the left:
 		var beforeCurrent = true;
 		$.each( this.options.values, function( i, v ) {
-			if( v.value === newValue ) {
+			if ( v.value === newValue ) {
 				return false;
 			}
-			if( v.value === self.$curr.data( 'value' ) ) {
+			if ( v.value === self.$curr.data( 'value' ) ) {
 				beforeCurrent = false;
 				return false;
 			}
 		} );
 
-		if( beforeCurrent ) {
+		if ( beforeCurrent ) {
 			margins.reverse();
 		}
 
-		if( this._isRtl() ) {
+		if ( this._isRtl() ) {
 			margins.reverse();
 		}
 
@@ -559,7 +558,7 @@ $.widget( 'ui.listrotator', {
 					} );
 
 					// Rotation target changed in the meantime, just abort selecting:
-					if( self._rotatingTo !== newValue ) {
+					if ( self._rotatingTo !== newValue ) {
 						return;
 					}
 
@@ -592,7 +591,7 @@ $.widget( 'ui.listrotator', {
 	activate: function( $section ) {
 		this.$curr.add( this.$auto ).removeClass( 'ui-state-hover ui-state-active' );
 
-		if( $section === undefined ) {
+		if ( $section === undefined ) {
 			$section = this.$curr;
 		}
 

--- a/lib/jquery.ui/jquery.ui.ooMenu.js
+++ b/lib/jquery.ui/jquery.ui.ooMenu.js
@@ -94,14 +94,13 @@ $.widget( 'ui.ooMenu', {
 	 * @throws {Error} when trying to set `items` or `customItems` option with improper values.
 	 */
 	_setOption: function( key, value ) {
-		if( key === 'items' || key === 'customItems' ) {
-			if( !$.isArray( value ) ) {
+		if ( key === 'items' || key === 'customItems' ) {
+			if ( !$.isArray( value ) ) {
 				throw new Error( key + ' needs to be an array' );
 			}
 
-			for( var i = 0; i < value.length; i++ ) {
-				if(
-					key === 'items' && !( value[i] instanceof $.ui.ooMenu.Item )
+			for ( var i = 0; i < value.length; i++ ) {
+				if ( key === 'items' && !( value[i] instanceof $.ui.ooMenu.Item )
 					|| key === 'customItems' && !( value[i] instanceof $.ui.ooMenu.CustomItem )
 				) {
 					throw new Error( key + ' may only feature specific instances' );
@@ -111,9 +110,9 @@ $.widget( 'ui.ooMenu', {
 
 		$.Widget.prototype._setOption.apply( this, arguments );
 
-		if( key === 'items' || key === 'customItems' ) {
+		if ( key === 'items' || key === 'customItems' ) {
 			this._refresh();
-		} else if( key === 'maxItems' ) {
+		} else if ( key === 'maxItems' ) {
 			this.scale();
 		}
 	},
@@ -125,12 +124,12 @@ $.widget( 'ui.ooMenu', {
 	_refresh: function() {
 		this.element.empty();
 		this.element.scrollTop( 0 );
-		for( var i = 0; i < this.options.items.length; i++ ) {
+		for ( var i = 0; i < this.options.items.length; i++ ) {
 			this._appendItem( this.options.items[i] );
 		}
 
-		for( var j = 0; j < this.options.customItems.length; j++ ) {
-			if( this._evaluateVisibility( this.options.customItems[j] ) ) {
+		for ( var j = 0; j < this.options.customItems.length; j++ ) {
+			if ( this._evaluateVisibility( this.options.customItems[j] ) ) {
 				this._appendItem( this.options.customItems[j] );
 			}
 		}
@@ -166,7 +165,7 @@ $.widget( 'ui.ooMenu', {
 			.attr( 'tabindex', -1 )
 			.html( label );
 
-		if( item.getLink() ) {
+		if ( item.getLink() ) {
 			$a.attr( 'href', item.getLink() );
 		}
 
@@ -176,14 +175,14 @@ $.widget( 'ui.ooMenu', {
 			.data( 'ui-ooMenu-item', item )
 			.append( $a );
 
-		if( item instanceof $.ui.ooMenu.CustomItem ) {
+		if ( item instanceof $.ui.ooMenu.CustomItem ) {
 			$item.addClass( 'ui-ooMenu-customItem' );
 
-			if( $.isFunction( item.getAction() ) ) {
+			if ( $.isFunction( item.getAction() ) ) {
 				$item.addClass( 'ui-ooMenu-customItem-action' );
 			}
 
-			if( item.getCssClass() ) {
+			if ( item.getCssClass() ) {
 				$item.addClass( item.getCssClass() );
 			}
 		}
@@ -196,7 +195,7 @@ $.widget( 'ui.ooMenu', {
 			self.deactivate();
 		} )
 		.on( 'mousedown.ooMenu', function( e ) {
-			if( !( e.which !== 1 || e.altKey || e.ctrlKey || e.shiftKey || e.metaKey ) ) {
+			if ( !( e.which !== 1 || e.altKey || e.ctrlKey || e.shiftKey || e.metaKey ) ) {
 				self.select( e );
 			}
 		} );
@@ -211,16 +210,16 @@ $.widget( 'ui.ooMenu', {
 	 * @return {boolean}
 	 */
 	hasVisibleItems: function( includeCustomItems ) {
-		if( this.options.items.length ) {
+		if ( this.options.items.length ) {
 			return true;
 		}
 
-		if( !includeCustomItems ) {
+		if ( !includeCustomItems ) {
 			return false;
 		}
 
-		for( var i = 0; i < this.options.customItems.length; i++ ) {
-			if( this._evaluateVisibility( this.options.customItems[i] ) ) {
+		for ( var i = 0; i < this.options.customItems.length; i++ ) {
+			if ( this._evaluateVisibility( this.options.customItems[i] ) ) {
 				return true;
 			}
 		}
@@ -239,13 +238,13 @@ $.widget( 'ui.ooMenu', {
 		.css( 'overflowY', 'visible' );
 
 		// Constrain height:
-		if( this.options.maxItems ) {
+		if ( this.options.maxItems ) {
 			var $children = this.element.children();
 
-			if( $children.length > this.options.maxItems ) {
+			if ( $children.length > this.options.maxItems ) {
 				var fixedHeight = 0;
 
-				for( var i = 0; i < this.options.maxItems; i++ ) {
+				for ( var i = 0; i < this.options.maxItems; i++ ) {
 					fixedHeight += $children.eq( i ).outerHeight();
 				}
 
@@ -256,7 +255,7 @@ $.widget( 'ui.ooMenu', {
 		}
 
 		// Constrain width if menu reaches out of the browser viewport:
-		if( this.element.offset().left + this.element.outerWidth( true ) > $( window ).width() ) {
+		if ( this.element.offset().left + this.element.outerWidth( true ) > $( window ).width() ) {
 			this.element.width(
 				$( window ).width()
 					- this.element.offset().left
@@ -286,11 +285,11 @@ $.widget( 'ui.ooMenu', {
 	activate: function( item ) {
 		var $item;
 
-		if( item instanceof $.ui.ooMenu.Item ) {
+		if ( item instanceof $.ui.ooMenu.Item ) {
 			$item = this.element.children( '.ui-ooMenu-item' ).filter( function() {
 				return $( this ).data( 'ui-ooMenu-item' ) === item;
 			} );
-		} else if( item instanceof jQuery && item.data( 'ui-ooMenu-item' ) ) {
+		} else if ( item instanceof jQuery && item.data( 'ui-ooMenu-item' ) ) {
 			$item = item;
 		} else {
 			throw new Error( 'Need $.ui.ooMenu.Item instance or menu item jQuery object to '
@@ -303,9 +302,9 @@ $.widget( 'ui.ooMenu', {
 			scroll = this.element.scrollTop(),
 			elementHeight = this.element.height();
 
-		if( offset < 0 ) {
+		if ( offset < 0 ) {
 			this.element.scrollTop( scroll + offset );
-		} else if( offset >= elementHeight ) {
+		} else if ( offset >= elementHeight ) {
 			this.element.scrollTop( scroll + offset - elementHeight + $item.height() );
 		}
 
@@ -318,7 +317,7 @@ $.widget( 'ui.ooMenu', {
 	 * Deactivates the menu (resets activated item).
 	 */
 	deactivate: function() {
-		if( this._isActive() ) {
+		if ( this._isActive() ) {
 			this.element.children( '.ui-state-hover' ).removeClass( 'ui-state-hover' );
 			$( this ).trigger( 'blur' );
 		}
@@ -356,20 +355,20 @@ $.widget( 'ui.ooMenu', {
 	 * @param {jQuery} $edge
 	 */
 	_move: function( direction, $edge ) {
-		if( !this.element.children().length ) {
+		if ( !this.element.children().length ) {
 			return;
 		}
 
 		var $active = this.element.children( '.ui-state-hover' );
 
-		if( !$active.length ) {
+		if ( !$active.length ) {
 			this.activate( $edge );
 			return;
 		}
 
 		var $nextItem = $active[direction + 'All']( '.ui-ooMenu-item' ).eq( 0 );
 
-		if( $nextItem.length ) {
+		if ( $nextItem.length ) {
 			this.activate( $nextItem );
 		} else {
 			this.activate( $edge );
@@ -384,9 +383,9 @@ $.widget( 'ui.ooMenu', {
 
 		var item = !$item.length ? null : $item.data( 'ui-ooMenu-item' );
 
-		if( item instanceof $.ui.ooMenu.CustomItem ) {
+		if ( item instanceof $.ui.ooMenu.CustomItem ) {
 			var action = item.getAction();
-			if( $.isFunction( action ) ) {
+			if ( $.isFunction( action ) ) {
 				action();
 			}
 		}
@@ -415,7 +414,7 @@ $.widget( 'ui.ooMenu', {
  * @throws {Error} if any required parameter is not specified properly.
  */
 var Item = function( label, value, link ) {
-	if( !label ) {
+	if ( !label ) {
 		throw new Error( 'Label needs to be specified' );
 	}
 
@@ -491,7 +490,7 @@ $.extend( Item.prototype, {
  * @throws {Error} if any required parameter is not specified properly.
  */
 var CustomItem = function( label, visibility, action, cssClass, link ) {
-	if( !label ) {
+	if ( !label ) {
 		throw new Error( 'Label needs to be specified' );
 	}
 
@@ -535,7 +534,7 @@ CustomItem = util.inherit(
 		 * @return {Function|boolean}
 		 */
 		getVisibility: function( menu ) {
-			if( $.isFunction( this._visibility ) ) {
+			if ( $.isFunction( this._visibility ) ) {
 				return this._visibility( menu );
 			}
 			return this._visibility !== false;

--- a/lib/jquery.ui/jquery.ui.preview.js
+++ b/lib/jquery.ui/jquery.ui.preview.js
@@ -55,7 +55,7 @@ $.widget( 'ui.preview', {
 	 */
 	_create: function() {
 		var hashBasedMessageProvider = new util.HashMessageProvider( this.options.messages );
-		if( this.options.messageProvider ) {
+		if ( this.options.messageProvider ) {
 			this._messageProvider = new util.CombiningMessageProvider(
 				this.options.messageProvider,
 				hashBasedMessageProvider
@@ -100,11 +100,11 @@ $.widget( 'ui.preview', {
 	update: function( value ) {
 		// No need to update the preview when the input value is clear(ed) since the preview
 		// will be hidden anyway.
-		if( this.options.$input && this.options.$input.val() === '' ) {
+		if ( this.options.$input && this.options.$input.val() === '' ) {
 			return;
 		}
 
-		if( value === null ) {
+		if ( value === null ) {
 			this.$value
 			.addClass( this.widgetBaseClass + '-novalue' )
 			.text( this._messageProvider.getMessage( 'novalue' ) );

--- a/lib/jquery.ui/jquery.ui.suggester.js
+++ b/lib/jquery.ui/jquery.ui.suggester.js
@@ -161,12 +161,12 @@ $.widget( 'ui.suggester', {
 		this.element
 		.addClass( 'ui-suggester-input' )
 		.on( 'blur.' + this.widgetName, function() {
-			if( !self.options.menu.element.is( ':focus' ) ) {
+			if ( !self.options.menu.element.is( ':focus' ) ) {
 				self._close();
 			}
 		} );
 
-		if( !( this.options.menu instanceof $.ui.ooMenu ) ) {
+		if ( !( this.options.menu instanceof $.ui.ooMenu ) ) {
 			var $menu = $( '<ul/>' ).ooMenu();
 			this.options.menu = $menu.data( 'ooMenu' );
 		}
@@ -189,7 +189,7 @@ $.widget( 'ui.suggester', {
 		this.option( 'menu', null );
 
 		// About to remove the last suggester instance on the page:
-		if( $( ':' + this.widgetBaseClass ).length === 1 ) {
+		if ( $( ':' + this.widgetBaseClass ).length === 1 ) {
 			$( window ).off( '.' + this.widgetBaseClass );
 		}
 
@@ -205,19 +205,19 @@ $.widget( 'ui.suggester', {
 	 * @protected
 	 */
 	_setOption: function( key, value ) {
-		if( key === 'menu' ) {
+		if ( key === 'menu' ) {
 			this.options.menu.destroy();
 			this.options.menu.element.remove();
 		}
 
 		var response = $.Widget.prototype._setOption.apply( this, arguments );
 
-		if( key === 'menu' && value instanceof $.ui.ooMenu ) {
+		if ( key === 'menu' && value instanceof $.ui.ooMenu ) {
 			this.options.menu = this._initMenu( value );
 		}
 
-		if( key === 'disabled' ) {
-			if( value ) {
+		if ( key === 'disabled' ) {
+			if ( value ) {
 				this._close();
 			}
 			this.element.prop( 'disabled', value );
@@ -243,13 +243,13 @@ $.widget( 'ui.suggester', {
 
 		$( ooMenu )
 		.on( 'selected.suggester', function( event, item ) {
-			if( item instanceof $.ui.ooMenu.Item && !( item instanceof $.ui.ooMenu.CustomItem ) ) {
+			if ( item instanceof $.ui.ooMenu.Item && !( item instanceof $.ui.ooMenu.CustomItem ) ) {
 				self._term = item.getValue();
 				self.element.val( item.getValue() );
 				self._close();
 				self._trigger( 'change' );
 
-				if( !event.originalEvent || !/^key/.test( event.originalEvent.type ) ) {
+				if ( !event.originalEvent || !/^key/.test( event.originalEvent.type ) ) {
 					setTimeout( function() {
 						// Run refocusing out of the execution chain to allow redrawing in IE.
 						self.element.focus();
@@ -273,7 +273,7 @@ $.widget( 'ui.suggester', {
 		.on( 'keydown.suggester', function( event ) {
 			var isDisabled = self.element.hasClass( 'ui-state-disabled' );
 
-			if( isDisabled || self.element.prop( 'readOnly' ) ) {
+			if ( isDisabled || self.element.prop( 'readOnly' ) ) {
 				return;
 			}
 
@@ -283,7 +283,7 @@ $.widget( 'ui.suggester', {
 
 			var keyCode = $.ui.keyCode;
 
-			switch( event.keyCode ) {
+			switch ( event.keyCode ) {
 				case keyCode.UP:
 					self._keyMove( 'previous', event );
 					break;
@@ -294,7 +294,7 @@ $.widget( 'ui.suggester', {
 
 				case keyCode.ENTER:
 				case keyCode.NUMPAD_ENTER:
-					if( self.options.menu.getActiveItem() ) {
+					if ( self.options.menu.getActiveItem() ) {
 						// Prevent form submission and select currently active item.
 						event.preventDefault();
 						event.stopPropagation();
@@ -304,7 +304,7 @@ $.widget( 'ui.suggester', {
 					break;
 
 				case keyCode.TAB:
-					if( !self.options.menu.getActiveItem() ) {
+					if ( !self.options.menu.getActiveItem() ) {
 						return;
 					}
 					self.options.menu.select( event );
@@ -312,14 +312,14 @@ $.widget( 'ui.suggester', {
 
 				case keyCode.ESCAPE:
 					self.element.val( self._term );
-					if( self.options.menu.element.is( ':visible' ) ) {
+					if ( self.options.menu.element.is( ':visible' ) ) {
 						event.stopPropagation();
 						self._close();
 					}
 					break;
 
 				default:
-					if( self.element.val() === ''
+					if ( self.element.val() === ''
 						&& (
 							event.keyCode === keyCode.BACKSPACE
 							|| event.keyCode === keyCode.DELETE
@@ -336,7 +336,7 @@ $.widget( 'ui.suggester', {
 			self._trigger( 'change' );
 		} )
 		.on( 'keypress.suggester', function( event ) {
-			if( suppressKeyPress ) {
+			if ( suppressKeyPress ) {
 				suppressKeyPress = false;
 				event.preventDefault();
 			}
@@ -364,8 +364,7 @@ $.widget( 'ui.suggester', {
 			$( ':' + self.widgetBaseClass ).each( function( i, node ) {
 				var suggester = $( node ).data( self.widgetName );
 				// Close suggester if not clicked on suggester or corresponding list:
-				if(
-					$target.closest( suggester.element ).length === 0
+				if ( $target.closest( suggester.element ).length === 0
 					&& $target.closest( suggester.options.menu.element ).length === 0
 				) {
 					suggester._close();
@@ -384,11 +383,11 @@ $.widget( 'ui.suggester', {
 
 		this._searching = setTimeout( function() {
 			// Only search if the value has changed:
-			if( self._term !== self.element.val() ) {
+			if ( self._term !== self.element.val() ) {
 				self.search()
 				.done( function() {
 					// Widget might have been destroyed in the meantime.
-					if( self.element.data( self.widgetName ) ) {
+					if ( self.element.data( self.widgetName ) ) {
 						self._trigger( 'change' );
 					}
 				} );
@@ -416,7 +415,7 @@ $.widget( 'ui.suggester', {
 		// Prevent moving cursor to beginning/end of the text field in some browsers:
 		event.preventDefault();
 
-		if( !this.options.menu.element.is( ':visible' ) ) {
+		if ( !this.options.menu.element.is( ':visible' ) ) {
 			this.search();
 			return;
 		}
@@ -424,7 +423,7 @@ $.widget( 'ui.suggester', {
 		var allItems = $.merge( [], this.options.menu.option( 'items' ) );
 		$.merge( allItems, this.options.menu.option( 'customItems' ) );
 
-		if( allItems.length > 0 ) {
+		if ( allItems.length > 0 ) {
 			this._move( direction, this.options.menu.getActiveItem(), allItems );
 		}
 	},
@@ -442,15 +441,15 @@ $.widget( 'ui.suggester', {
 			isFirst = activeItem === allItems[0],
 			isLast = activeItem === allItems[allItems.length - 1];
 
-		if( isFirst && direction === 'previous' || isLast && direction === 'next' ) {
+		if ( isFirst && direction === 'previous' || isLast && direction === 'next' ) {
 			this._moveOffEdge( direction );
 		} else {
 			$( this.options.menu ).one( 'focus.suggester', function( event, item ) {
 				var isCustomMenuItem = item instanceof $.ui.ooMenu.CustomItem;
 
-				if( item instanceof $.ui.ooMenu.Item && !isCustomMenuItem ) {
+				if ( item instanceof $.ui.ooMenu.Item && !isCustomMenuItem ) {
 					self.element.val( item.getValue() );
-				} else if( isCustomMenuItem ) {
+				} else if ( isCustomMenuItem ) {
 					self.element.val( self._term );
 				}
 				self._trigger( 'change' );
@@ -488,7 +487,7 @@ $.widget( 'ui.suggester', {
 
 		this._term = this.element.val();
 
-		if( this._term.length < this.options.minTermLength ) {
+		if ( this._term.length < this.options.minTermLength ) {
 			this._close();
 			return deferred.resolve( [], this._term ).promise();
 		}
@@ -500,11 +499,11 @@ $.widget( 'ui.suggester', {
 		.done( function( suggestions, requestTerm ) {
 			self._searching = false;
 
-			if( typeof requestTerm === 'string' && requestTerm !== self._term ) {
+			if ( typeof requestTerm === 'string' && requestTerm !== self._term ) {
 				// Skip request since it does not correspond to the current search term.
 				return;
 			}
-			if( self.options.menu ) {
+			if ( self.options.menu ) {
 				// Suggester (including the menu) might have been destroyed in the meantime.
 				self._updateMenu( suggestions, requestTerm );
 			}
@@ -514,7 +513,7 @@ $.widget( 'ui.suggester', {
 			self._trigger( 'error', null, [message] );
 		} )
 		.always( function() {
-			if( --self._pending === 0 ) {
+			if ( --self._pending === 0 ) {
 				self.element.removeClass( 'ui-suggester-loading' );
 			}
 		} );
@@ -525,7 +524,7 @@ $.widget( 'ui.suggester', {
 	 * @protected
 	 */
 	_clearTimeout: function() {
-		if( typeof this._searching !== 'boolean' ) {
+		if ( typeof this._searching !== 'boolean' ) {
 			clearTimeout( this._searching );
 		}
 	},
@@ -552,7 +551,7 @@ $.widget( 'ui.suggester', {
 	_updateMenuItems: function( suggestions, requestTerm ) {
 		var menuItems = [];
 
-		for( var i = 0; i < suggestions.length; i++ ) {
+		for ( var i = 0; i < suggestions.length; i++ ) {
 			menuItems.push( this._createMenuItemFromSuggestion( suggestions[i], requestTerm ) );
 		}
 
@@ -564,7 +563,7 @@ $.widget( 'ui.suggester', {
 	 * @protected
 	 */
 	_updateMenuVisibility: function() {
-		if( !this.options.menu.hasVisibleItems( true ) ) {
+		if ( !this.options.menu.hasVisibleItems( true ) ) {
 			this._close();
 		} else {
 			this._open();
@@ -597,7 +596,7 @@ $.widget( 'ui.suggester', {
 	 * @return {string} return.fail.message
 	 */
 	_getSuggestions: function( term ) {
-		if( typeof this.options.source === 'function' ) {
+		if ( typeof this.options.source === 'function' ) {
 			return this.options.source( term );
 		}
 
@@ -645,7 +644,7 @@ $.widget( 'ui.suggester', {
 	 * @protected
 	 */
 	_open: function() {
-		if( this.options.menu.element.is( ':visible' ) ) {
+		if ( this.options.menu.element.is( ':visible' ) ) {
 			return;
 		}
 
@@ -660,7 +659,7 @@ $.widget( 'ui.suggester', {
 	 * @protected
 	 */
 	_close: function() {
-		if( !this.options.menu.element.is( ':visible' ) ) {
+		if ( !this.options.menu.element.is( ':visible' ) ) {
 			return;
 		}
 
@@ -681,7 +680,7 @@ $.widget( 'ui.suggester', {
 		var position = $.extend( {}, this.options.position ),
 			$menu = this.options.menu.element;
 
-		if( dir === 'rtl' ) {
+		if ( dir === 'rtl' ) {
 			position = flipPosition( position );
 		}
 
@@ -691,14 +690,14 @@ $.widget( 'ui.suggester', {
 
 		$menu.zIndex( this.element.zIndex() + 1 );
 
-		if( this.element.attr( 'lang' ) ) {
+		if ( this.element.attr( 'lang' ) ) {
 			$menu.attr( 'lang', this.element.attr( 'lang' ) );
 		}
 		$menu.attr( 'dir', dir );
 
 		this.options.menu.scale();
 
-		if( this.options.confineMinWidthTo !== null ) {
+		if ( this.options.confineMinWidthTo !== null ) {
 			var $minWidthConfinement = this.options.confineMinWidthTo || this.element;
 
 			$menu.css(
@@ -719,7 +718,7 @@ $.widget( 'ui.suggester', {
  */
 function flipPosition( position ) {
 	function flipOrientation( orientation ) {
-		if( /right/i.test( orientation ) ) {
+		if ( /right/i.test( orientation ) ) {
 			return orientation.replace( /right/i, 'left' );
 		} else {
 			return orientation.replace( /left/i, 'right' );
@@ -737,7 +736,7 @@ function flipPosition( position ) {
 	position.my = flipOrientation( position.my );
 	position.at = flipOrientation( position.at );
 
-	if( position.offset ) {
+	if ( position.offset ) {
 		position.offset = flipHorizontalOffset( position.offset );
 	}
 

--- a/lib/jquery.ui/jquery.ui.toggler.js
+++ b/lib/jquery.ui/jquery.ui.toggler.js
@@ -87,7 +87,7 @@ $.widget( 'ui.toggler', {
 	_create: function() {
 		var self = this;
 
-		if( !this.options.$subject ) {
+		if ( !this.options.$subject ) {
 			throw new Error( 'No subject given: Nothing to toggle.' );
 		}
 
@@ -107,7 +107,7 @@ $.widget( 'ui.toggler', {
 		.on( 'click.' + this.widgetName, function( event ) {
 			event.preventDefault();
 
-			if( !self.element.hasClass( 'ui-state-disabled' ) ) {
+			if ( !self.element.hasClass( 'ui-state-disabled' ) ) {
 				// Change toggle icon to reflect current state of toggle subject visibility:
 				var visible = self._reflectVisibilityOnToggleIcon( true );
 
@@ -158,14 +158,14 @@ $.widget( 'ui.toggler', {
 			dir = ( isRtl === undefined ? $( 'body' ).hasClass( 'rtl' ) : isRtl ) ? 'w' : 'e',
 		// Don't use is( ':visible' ) which would be misleading if element not yet in DOM!
 			visible = this.options.$subject.css( 'display' ) !== 'none';
-		if( inverted ) {
+		if ( inverted ) {
 			visible = !visible;
 		}
 
 		this.$toggleIcon.removeClass( iconClass + 'e ' + iconClass + 's ' + iconClass + 'w '
 			+ this.widgetBaseClass + '-icon3dtrans' );
 		// Add classes displaying rotated icon. If CSS3 transform is available, use it:
-		if( !browserSupportsTransform || !$.speed().duration ) {
+		if ( !browserSupportsTransform || !$.speed().duration ) {
 			this.$toggleIcon.addClass( iconClass + ( visible ? 's' : dir ) );
 		} else {
 			this.$toggleIcon.addClass( iconClass + 's '

--- a/lib/jquery.ui/jquery.ui.unitsuggester.js
+++ b/lib/jquery.ui/jquery.ui.unitsuggester.js
@@ -97,10 +97,10 @@ $.widget( 'ui.unitsuggester', PARENT, {
 		this._searchTimeoutHandle = setTimeout( function() {
 			self.search()
 			.done( function( suggestions, requestTerm ) {
-				if( requestTerm !== self.element.val() ) {
+				if ( requestTerm !== self.element.val() ) {
 					return;
 				}
-				if( self.options.menu.element.is( ':visible' ) ) {
+				if ( self.options.menu.element.is( ':visible' ) ) {
 					self._selectFirstUnit();
 				} else {
 					self._trigger( 'selected', null, [null] );
@@ -114,12 +114,12 @@ $.widget( 'ui.unitsuggester', PARENT, {
 			menuItems = menu.option( 'items' ),
 			url = null;
 
-		if( menuItems.length > 0 && menu.element.is( ':visible' ) ) {
+		if ( menuItems.length > 0 && menu.element.is( ':visible' ) ) {
 			this.options.menu.activate( menuItems[0] );
 			url = menuItems[0]._link;
 		}
 
-		if( this._selectedUrl !== url ) {
+		if ( this._selectedUrl !== url ) {
 			this._selectedUrl = url;
 			this._trigger( 'selected', null, [url] );
 		}
@@ -203,7 +203,7 @@ $.widget( 'ui.unitsuggester', PARENT, {
 		var $suggestion = $( '<span class="ui-unitsuggester-itemcontent">' ),
 			$label = $( '<span class="ui-unitsuggester-label">' ).text( entityStub.label || entityStub.id );
 
-		if( entityStub.aliases ) {
+		if ( entityStub.aliases ) {
 			$label.append(
 				$( '<span class="ui-unitsuggester-aliases">' ).text( ' (' + entityStub.aliases.join( ', ' ) +  ')' )
 			);
@@ -211,7 +211,7 @@ $.widget( 'ui.unitsuggester', PARENT, {
 
 		$suggestion.append( $label );
 
-		if( entityStub.description ) {
+		if ( entityStub.description ) {
 			$suggestion.append(
 				$( '<span class="ui-unitsuggester-description">' )
 					.text( entityStub.description )
@@ -256,7 +256,7 @@ $.widget( 'ui.unitsuggester', PARENT, {
 
 		this.options.menu.element
 		.on( 'mouseleave', function() {
-			if( self.options.menu.element.is( ':visible' ) ) {
+			if ( self.options.menu.element.is( ':visible' ) ) {
 				self._selectedSite = null;
 				self._selectFirstUnit();
 			}
@@ -276,7 +276,7 @@ $.widget( 'ui.unitsuggester', PARENT, {
 		.then( function( suggestions, searchTerm, nextSuggestionOffset ) {
 			var deferred = $.Deferred();
 
-			if( self._cache[searchTerm] ) {
+			if ( self._cache[searchTerm] ) {
 				self._cache[searchTerm].suggestions = self._cache[searchTerm].suggestions.concat( suggestions );
 				self._cache[searchTerm].nextSuggestionOffset = nextSuggestionOffset;
 			} else {

--- a/lib/jquery.util/jquery.util.adaptlettercase.js
+++ b/lib/jquery.util/jquery.util.adaptlettercase.js
@@ -21,17 +21,17 @@ jQuery.util.adaptlettercase = ( function( $ ) {
 	 * @throws {Error} if destination and/or source string is/are not specified.
 	 */
 	return function( destination, source, method ) {
-		if( !destination || !source ) {
+		if ( !destination || !source ) {
 			throw new Error( 'Destination and source need to be specified.' );
 		}
 
-		if( source.toLowerCase().indexOf( destination.toLowerCase() ) !== 0 ) {
+		if ( source.toLowerCase().indexOf( destination.toLowerCase() ) !== 0 ) {
 			return destination;
 		}
 
-		if( method === 'all' ) {
+		if ( method === 'all' ) {
 			return source.substr( 0, destination.length );
-		} else if( method === 'first' ) {
+		} else if ( method === 'first' ) {
 			return source.substr( 0, 1 ) + destination.substr( 1 );
 		} else {
 			return destination;

--- a/lib/jquery.util/jquery.util.getscrollbarwidth.js
+++ b/lib/jquery.util/jquery.util.getscrollbarwidth.js
@@ -15,7 +15,7 @@ jQuery.util.getscrollbarwidth = ( function( $ ) {
 	var scrollbarWidth;
 
 	return function() {
-		if( scrollbarWidth ) {
+		if ( scrollbarWidth ) {
 			return scrollbarWidth;
 		}
 

--- a/lib/jquery/jquery.AnimationEvent.js
+++ b/lib/jquery/jquery.AnimationEvent.js
@@ -47,10 +47,10 @@ jQuery.AnimationEvent = ( function( $, PurposedCallbacks ) {
 	 * @throws {Error} when the animation purpose is not specified.
 	 */
 	var SELF = function AnimationEvent( animationPurpose, props ) {
-		if( !( this instanceof SELF ) ) {
+		if ( !( this instanceof SELF ) ) {
 			return new SELF( animationPurpose, props );
 		}
-		if( typeof animationPurpose !== 'string' || $.trim( animationPurpose ) === '' ) {
+		if ( typeof animationPurpose !== 'string' || $.trim( animationPurpose ) === '' ) {
 			throw new Error( 'An animation purpose has to be stated' );
 		}
 
@@ -108,7 +108,7 @@ jQuery.AnimationEvent = ( function( $, PurposedCallbacks ) {
 		 *         `animationOptions()` for two different animations.
 		 */
 		this.animationOptions = function( baseOptions ) {
-			if( this.animation ) {
+			if ( this.animation ) {
 				throw new Error( 'The AnimationEvent instance\'s generated animation options are ' +
 					'used within some animation already, they can not be used in two animations.' );
 			}
@@ -119,18 +119,18 @@ jQuery.AnimationEvent = ( function( $, PurposedCallbacks ) {
 				// Consider callbacks defined in the given options, they should be called first.
 				var baseCallback = baseOptions[ purpose ];
 				var finalCallback = function() {
-					if( baseCallback ) {
+					if ( baseCallback ) {
 						baseCallback.apply( this, arguments );
 					}
 					callbacksList.fireWith( this, [ purpose ], arguments );
 				};
-				if( purpose === 'start' ) {
+				if ( purpose === 'start' ) {
 					options.start = function() {
 						// If "start" gets called, this means the generated options are used within
 						// an jQuery.Animation. Tell the AnimationEvent instance which has created
 						// these options which jQuery.Animation object it is related to.
 						var animation = arguments[0];
-						if( self.animation && self.animation !== animation ) {
+						if ( self.animation && self.animation !== animation ) {
 							throw new Error( 'Can not use the same AnimationEvent instance\'s '
 								+ 'animationOptions() for two different animations.' );
 						}

--- a/lib/jquery/jquery.PurposedCallbacks.js
+++ b/lib/jquery/jquery.PurposedCallbacks.js
@@ -47,11 +47,11 @@ jQuery.PurposedCallbacks = ( function( $ ) {
 	 * @throws {Error} if purpose is unknown.
 	 */
 	var SELF = function PurposedCallbacks( predefinedPurposes, callbackOptions ) {
-		if( !( this instanceof SELF ) ) {
+		if ( !( this instanceof SELF ) ) {
 			return new SELF( predefinedPurposes, callbackOptions );
 		}
 
-		if( typeof predefinedPurposes === 'string' ) {
+		if ( typeof predefinedPurposes === 'string' ) {
 			callbackOptions = predefinedPurposes;
 			predefinedPurposes = undefined;
 		}
@@ -81,11 +81,11 @@ jQuery.PurposedCallbacks = ( function( $ ) {
 		 *         one of them.
 		 */
 		this.add = function( purpose, callbacks ) {
-			if( predefinedPurposes && !this.has( purpose ) ) {
+			if ( predefinedPurposes && !this.has( purpose ) ) {
 				throw new Error( 'Unknown purpose "' + purpose + '".' );
 			}
 
-			if( !callbacksPerPurpose[ purpose ] ) {
+			if ( !callbacksPerPurpose[ purpose ] ) {
 				callbacksPerPurpose[ purpose ] = $.Callbacks( callbackOptions );
 			}
 			callbacksPerPurpose[ purpose ].add( callbacks );
@@ -102,7 +102,7 @@ jQuery.PurposedCallbacks = ( function( $ ) {
 		 */
 		this.remove = function( purpose, callbacks ) {
 			var callbackForPurpose = callbacksPerPurpose[ purpose ];
-			if( callbackForPurpose ) {
+			if ( callbackForPurpose ) {
 				// NOTE: We can't remove( callbacks ) even though it is documented to work this way.
 				//  This is a bug (behavior not according to jQuery API documentation) which is
 				//  still present in jQuery 2.0
@@ -121,7 +121,7 @@ jQuery.PurposedCallbacks = ( function( $ ) {
 		 * @return {boolean}
 		 */
 		this.has = function( purpose, callback ) {
-			if( callback ) {
+			if ( callback ) {
 				var callbacksForPurpose = callbacksPerPurpose[ purpose ];
 				return callbacksForPurpose && callbacksForPurpose.has( callback );
 			}
@@ -138,11 +138,11 @@ jQuery.PurposedCallbacks = ( function( $ ) {
 		 * @return {string[]}
 		 */
 		this.purposes = function() {
-			if( predefinedPurposes ) {
+			if ( predefinedPurposes ) {
 				return predefinedPurposes.slice();
 			}
 			var usedPurposes = [];
-			for( var purpose in callbacksPerPurpose ) {
+			for ( var purpose in callbacksPerPurpose ) {
 				usedPurposes.push( purpose );
 			}
 			return usedPurposes;
@@ -173,7 +173,7 @@ jQuery.PurposedCallbacks = ( function( $ ) {
 		 *         here is not one of them.
 		 */
 		this.fireWith = function( context, purposes, args ) {
-			if( !$.isArray( purposes ) ) {
+			if ( !$.isArray( purposes ) ) {
 				purposes = [ purposes ];
 			}
 			args = args || [];
@@ -181,16 +181,16 @@ jQuery.PurposedCallbacks = ( function( $ ) {
 
 			$.each( purposes, function( i, purpose ) {
 				var callbacksForPurpose = callbacksPerPurpose[ purpose ];
-				if( callbacksForPurpose ) {
+				if ( callbacksForPurpose ) {
 					callbacksForPurpose.fireWith( context, args );
 				} else {
 					missingPurposes.push( purpose );
 				}
 			} );
 
-			if( predefinedPurposes && missingPurposes.length ) {
+			if ( predefinedPurposes && missingPurposes.length ) {
 				var unknownPurposes = $( missingPurposes ).not( predefinedPurposes );
-				if( unknownPurposes.length ) {
+				if ( unknownPurposes.length ) {
 					throw new Error( 'Can not fire callbacks for unknown purposes.' );
 				}
 			}
@@ -208,7 +208,7 @@ jQuery.PurposedCallbacks = ( function( $ ) {
 		 * @return {jQuery.PurposedCallbacks.Facade}
 		 */
 		this.facade = function() {
-			if( !facade ) {
+			if ( !facade ) {
 				facade = SELF.Facade( this );
 			}
 			return facade;
@@ -229,7 +229,7 @@ jQuery.PurposedCallbacks = ( function( $ ) {
 	 * @return {jQuery.PurposedCallbacks.Facade} Can be instantiated without `new`.
 	 */
 	SELF.Facade = function PurposedCallbacksFacade( base ) {
-		if( !( this instanceof SELF.Facade ) ) {
+		if ( !( this instanceof SELF.Facade ) ) {
 			return new SELF.Facade( base );
 		}
 		var self = this;

--- a/lib/jquery/jquery.animateWithEvent.js
+++ b/lib/jquery/jquery.animateWithEvent.js
@@ -51,7 +51,7 @@ jQuery.fn.animateWithEvent = ( function( $ ) {
 		startCallback
 	) {
 		var animationFunction;
-		if( typeof animationProperties !== 'string' ) {
+		if ( typeof animationProperties !== 'string' ) {
 			// Custom animation, forward to jQuery.fn.animate( animationProperties, options )
 			animationFunction = 'animate';
 			animationProperties = animationProperties || {}; // allow "empty" animation
@@ -59,12 +59,12 @@ jQuery.fn.animateWithEvent = ( function( $ ) {
 			// Predefined animation, e.g. "fadeIn" would forward to jQuery.fn.fadeIn( options )
 			animationFunction = animationProperties;
 			animationProperties = false;
-			if( !$.isFunction( $.fn[ animationFunction ] ) ) {
+			if ( !$.isFunction( $.fn[ animationFunction ] ) ) {
 				throw new Error( 'jQuery.fn."' + animationFunction + '" is not a function.' );
 			}
 		}
 
-		if( $.isFunction( options ) || !options ) {
+		if ( $.isFunction( options ) || !options ) {
 			startCallback = options;
 			options = {};
 		}
@@ -82,13 +82,13 @@ jQuery.fn.animateWithEvent = ( function( $ ) {
 					// All event listeners can then register their callbacks for different animation
 					// stages to animationEvent.animationCallbacks.
 					startCallback.call( this, animationEvent );
-					if( options.start ) {
+					if ( options.start ) {
 						options.start.apply( this, arguments );
 					}
 				}
 			} ) );
 
-			if( animationProperties ) {
+			if ( animationProperties ) {
 				// animate()
 				$( elem )[ animationFunction ]( animationProperties, animationOptions );
 			} else {

--- a/lib/jquery/jquery.autocompletestring.js
+++ b/lib/jquery/jquery.autocompletestring.js
@@ -16,8 +16,8 @@ jQuery.fn.autocompletestring = ( function( $ ) {
 	 * @return {jQuery}
 	 */
 	var autocompletestring = function( incomplete, complete ) {
-		if(
-			!incomplete || !complete
+		if ( !incomplete
+			|| !complete
 			|| complete.toLowerCase().indexOf( incomplete.toLowerCase() ) !== 0
 		) {
 			return this;
@@ -27,7 +27,7 @@ jQuery.fn.autocompletestring = ( function( $ ) {
 			var $this = $( this );
 
 			// Only auto-complete when incomplete string actually is a part of the complete string:
-			if( incomplete === complete.substr( 0, incomplete.length ) ) {
+			if ( incomplete === complete.substr( 0, incomplete.length ) ) {
 				$this.val( incomplete + complete.substr( incomplete.length ) );
 			}
 
@@ -45,25 +45,25 @@ jQuery.fn.autocompletestring = ( function( $ ) {
 	 * @return {number} Text selection length.
 	 */
 	autocompletestring.selectText = function( node, start, end ) {
-		if( end > node.value.length ) {
+		if ( end > node.value.length ) {
 			end = node.value.length;
 		}
 
-		if( start > end ) {
+		if ( start > end ) {
 			return 0;
 		}
 
-		if( node.createTextRange ) { // Opera < 10.5 and IE
+		if ( node.createTextRange ) { // Opera < 10.5 and IE
 			var selRange = node.createTextRange();
 			selRange.collapse( true );
 			selRange.moveStart( 'character', start );
 			selRange.moveEnd( 'character', end );
 			selRange.select();
-		} else if( node.setSelectionRange ) { // major modern browsers
+		} else if ( node.setSelectionRange ) { // major modern browsers
 			// Make a 'backward' selection so pressing arrow left won't put the cursor near the
 			// selections end but rather at the typing position:
 			node.setSelectionRange( start, end, 'backward' );
-		} else if( node.selectionStart ) {
+		} else if ( node.selectionStart ) {
 			node.selectionStart = start;
 			node.selectionEnd = end;
 		}

--- a/lib/jquery/jquery.focusAt.js
+++ b/lib/jquery/jquery.focusAt.js
@@ -30,8 +30,8 @@ jQuery.fn.focusAt = ( function( $ ) {
 		// non-input element, there will still an error be thrown for consistence.
 		var normalizedPosition = normalizePosition( position, $elem );
 
-		if( $elem.length ) {
-			if( !$elem.is( ':input' ) ) {
+		if ( $elem.length ) {
+			if ( !$elem.is( ':input' ) ) {
 				$elem.focus(); // simple focus suffices since this is not an input element
 			} else {
 				setCaretPosition( $elem[0], normalizedPosition );
@@ -54,11 +54,11 @@ jQuery.fn.focusAt = ( function( $ ) {
 	function normalizePosition( position, $forElem ) {
 		var textLength = $forElem.val().length;
 
-		if( typeof position === 'number' ) {
+		if ( typeof position === 'number' ) {
 			return calculateAbsolutePosition( position, textLength );
-		} else if( position === 'end' ) {
+		} else if ( position === 'end' ) {
 			return textLength; // behind last character
-		} else if( position === 'start' ) {
+		} else if ( position === 'start' ) {
 			return 0;
 		}
 		throw new Error( 'Focus Position has to be a number or string "start" or "end"' );
@@ -75,7 +75,7 @@ jQuery.fn.focusAt = ( function( $ ) {
 	 * @return {number}
 	 */
 	function calculateAbsolutePosition( relativePosition, totalLength ) {
-		if( relativePosition < 0 ) {
+		if ( relativePosition < 0 ) {
 			relativePosition = totalLength + relativePosition;
 			return relativePosition < 0 ? 0 : relativePosition;
 		} else {
@@ -94,13 +94,13 @@ jQuery.fn.focusAt = ( function( $ ) {
 	function setCaretPosition( elem, caretPos ) {
 		var range;
 
-		if( elem.createTextRange ) {
+		if ( elem.createTextRange ) {
 			range = elem.createTextRange();
 			range.move( 'character', caretPos );
 			range.select();
 		} else {
 			elem.focus();
-			if( elem.selectionStart !== undefined ) {
+			if ( elem.selectionStart !== undefined ) {
 				elem.setSelectionRange( caretPos, caretPos );
 			}
 		}

--- a/lib/jquery/jquery.inputautoexpand.js
+++ b/lib/jquery/jquery.inputautoexpand.js
@@ -44,7 +44,7 @@
  *        Namespace used for the events the plugin attaches handlers to.
  */
 $.fn.inputautoexpand = function( options ) {
-	if( !options ) {
+	if ( !options ) {
 		options = {};
 	}
 
@@ -65,9 +65,9 @@ $.fn.inputautoexpand = function( options ) {
 	this.filter( 'input:text, textarea' ).each( function() {
 		var instance = $.data( this, 'inputautoexpand' );
 
-		if( instance ) {
+		if ( instance ) {
 			// AutoExpand initialized already, update options only (will also expand):
-			if( options ) {
+			if ( options ) {
 				instance.options( options );
 			}
 			instance.expand();
@@ -103,7 +103,7 @@ $.AutoExpandInput = function( element, options ) {
 	this._nodeName = element.nodeName;
 
 	this.$input.on( 'eachchange', function( event, oldValue ) {
-		if( self._options.suppressNewLine ) {
+		if ( self._options.suppressNewLine ) {
 			self.$input.val( self.$input.val().replace( /\r?\n/g, '' ) );
 		}
 		self.expand();
@@ -121,7 +121,7 @@ $.AutoExpandInput = function( element, options ) {
 	.on( 'resize.' + this._options.eventNamespace, function( event ) {
 		$( 'input:text, textarea' ).each( function() {
 			var instance = $.data( this, 'inputautoexpand' );
-			if( instance ) {
+			if ( instance ) {
 				instance.expand();
 			}
 		} );
@@ -167,15 +167,15 @@ $.extend( $.AutoExpandInput.prototype, {
 	expand: function( force ) {
 		var newVal = this.$input.val();
 
-		if( !force && newVal === this._previousVal ) {
+		if ( !force && newVal === this._previousVal ) {
 			return;
 		}
 
-		if( this._options.expandWidth ) {
+		if ( this._options.expandWidth ) {
 			this._expandWidth();
 		}
 
-		if( this._options.expandHeight && this._nodeName === 'TEXTAREA' ) {
+		if ( this._options.expandHeight && this._nodeName === 'TEXTAREA' ) {
 			this._expandHeight();
 		}
 
@@ -195,16 +195,16 @@ $.extend( $.AutoExpandInput.prototype, {
 
 		// Since the minimum width may have been calculated dynamically using the placeholder,
 		// the minimum width may be greater than the maximum width.
-		if( minWidth > maxWidth ) {
+		if ( minWidth > maxWidth ) {
 			minWidth = maxWidth;
 		}
 
 		var valWidth = this._getWidthFor( this.$input.val() ),
 			newWidth = valWidth + comfortZone;
 
-		if( newWidth < minWidth ) {
+		if ( newWidth < minWidth ) {
 			newWidth = minWidth;
-		} else if( newWidth >= maxWidth  ) {
+		} else if ( newWidth >= maxWidth  ) {
 			newWidth = maxWidth;
 		}
 
@@ -223,11 +223,11 @@ $.extend( $.AutoExpandInput.prototype, {
 			minHeight = this._options.minHeight || 0,// keeps at least one single line
 			maxHeight = this._options.maxHeight;
 
-		if( maxHeight && newHeight > maxHeight ) {
+		if ( maxHeight && newHeight > maxHeight ) {
 			input.style.height = maxHeight + 'px';
 			input.style.overflow = 'scroll';
 		} else {
-			if( minHeight && newHeight < minHeight ) {
+			if ( minHeight && newHeight < minHeight ) {
 				input.style.height = minHeight + 'px';
 			} else {
 				input.style.height = ( !isNaN( newHeight ) ? newHeight : 0 ) + 'px';
@@ -257,13 +257,13 @@ $.extend( $.AutoExpandInput.prototype, {
 	 * @return {number}
 	 */
 	_getMinWidth: function() {
-		if( this._options.minWidth ) {
+		if ( this._options.minWidth ) {
 			return this._options.minWidth;
 		}
 
 		// If there is no static minimum width, the placeholder is used to detect the minimum width
 		// Since the placeholder may change, its width is calculated always.
-		if( !this.$input.attr( 'placeholder' ) ) {
+		if ( !this.$input.attr( 'placeholder' ) ) {
 			return 0;
 		}
 		// Don't need comfort zone in this case, just some sane space:
@@ -279,7 +279,7 @@ $.extend( $.AutoExpandInput.prototype, {
 	 * @return {number}
 	 */
 	_getHeightFor: function( text ) {
-		if( text === '' ) {
+		if ( text === '' ) {
 			text = ' ';
 		}
 
@@ -288,12 +288,12 @@ $.extend( $.AutoExpandInput.prototype, {
 
 		// Update the width in case the original textarea width has changed:
 		var width = this._options.maxWidth;
-		if( !this._options.expandWidth || this.$input.width() > this._options.maxWidth ) {
+		if ( !this._options.expandWidth || this.$input.width() > this._options.maxWidth ) {
 			width = Math.ceil( this.$input.width() ) - 1;
 		}
 
 		// Catch miscalculation:
-		if( width < 0 ) {
+		if ( width < 0 ) {
 			width = 0;
 		}
 
@@ -329,11 +329,11 @@ $.extend( $.AutoExpandInput.prototype, {
 	 *         initialization.
 	 */
 	options: function( options ) {
-		if( !options ) {
+		if ( !options ) {
 			return this._options;
 		}
 
-		if( options.eventNamespace ) {
+		if ( options.eventNamespace ) {
 			throw new Error( 'Cannot alter eventNamespace after initialization.' );
 		}
 
@@ -349,13 +349,13 @@ $.extend( $.AutoExpandInput.prototype, {
 		var hasRemainingInstances = false;
 
 		$( 'input' ).each( function() {
-			if( $.data( this, 'inputautoexpand' ) ) {
+			if ( $.data( this, 'inputautoexpand' ) ) {
 				hasRemainingInstances = true;
 				return false;
 			}
 		} );
 
-		if( !hasRemainingInstances ) {
+		if ( !hasRemainingInstances ) {
 			$( 'window' ).off( this._options.eventNamespace );
 			destroyRulers();
 		}
@@ -374,7 +374,7 @@ var $rulerX, $rulerY;
  * @ignore
  */
 function initRulers() {
-	if( !$rulerX ) {
+	if ( !$rulerX ) {
 		$rulerX = $( '<div/>' )
 			.css( {
 				width: 'auto',
@@ -387,11 +387,11 @@ function initRulers() {
 			} );
 	}
 
-	if( !$rulerX.closest( 'body' ).length ) {
+	if ( !$rulerX.closest( 'body' ).length ) {
 		$rulerX.appendTo( 'body' );
 	}
 
-	if( !$rulerY ) {
+	if ( !$rulerY ) {
 		$rulerY = $( '<textarea style="min-height: 0!important; height: 0!important;"/>' )
 			.attr( 'tabindex', '-1' )
 			.css( {
@@ -403,7 +403,7 @@ function initRulers() {
 			} );
 	}
 
-	if( !$rulerY.closest( 'body' ).length ) {
+	if ( !$rulerY.closest( 'body' ).length ) {
 		$rulerY.appendTo( 'body' );
 	}
 }
@@ -413,11 +413,11 @@ function initRulers() {
  * @ignore
  */
 function destroyRulers() {
-	if( $rulerX ) {
+	if ( $rulerX ) {
 		$rulerX.remove();
 		$rulerX = null;
 	}
-	if( $rulerY ) {
+	if ( $rulerY ) {
 		$rulerY.remove();
 		$rulerY.remove();
 	}
@@ -445,7 +445,7 @@ function copySpaceAffectingStyles( $from, $to ) {
 		'wordWrap'
 	];
 
-	for( var i = 0; i < stylesToCopy.length; i++ ) {
+	for ( var i = 0; i < stylesToCopy.length; i++ ) {
 		$to.css( stylesToCopy[i], $from.css( stylesToCopy[i] ) );
 	}
 

--- a/lib/util/util.Extendable.js
+++ b/lib/util/util.Extendable.js
@@ -43,7 +43,7 @@ this.util = this.util || {};
 		callExtensions: function( callName, args ) {
 			args = args || [];
 			$.each( this._extensions, function( key, ext ) {
-				if( ext[callName] ) {
+				if ( ext[callName] ) {
 					ext[callName].apply( ext, args );
 				}
 			} );

--- a/lib/util/util.Notifier.js
+++ b/lib/util/util.Notifier.js
@@ -40,13 +40,13 @@ util.Notifier = ( function() {
 	 */
 	var SELF = function Notifier( notificationMap ) {
 		// allow instance without "new":
-		if( !( this instanceof SELF ) ) {
+		if ( !( this instanceof SELF ) ) {
 			return new SELF( notificationMap );
 		}
 
-		if( !notificationMap ) {
+		if ( !notificationMap ) {
 			notificationMap = {};
-		} else if( typeof notificationMap !== 'object' ) {
+		} else if ( typeof notificationMap !== 'object' ) {
 			throw new Error( 'Notifier requires a notification map in form of an object' );
 		}
 
@@ -62,7 +62,7 @@ util.Notifier = ( function() {
 		this.notify = function( notification, args ) {
 			var notifyCallback = notificationMap[ notification ];
 
-			if( !notifyCallback ) {
+			if ( !notifyCallback ) {
 				return false;
 			}
 

--- a/lib/util/util.highlightSubstring.js
+++ b/lib/util/util.highlightSubstring.js
@@ -26,7 +26,7 @@ this.util = this.util || {};
  * @return {string}
  */
 util.highlightSubstring = function( substring, string, options ) {
-	if( substring === '' || string === '' ) {
+	if ( substring === '' || string === '' ) {
 		return string;
 	}
 
@@ -44,20 +44,19 @@ util.highlightSubstring = function( substring, string, options ) {
 
 	var indexOfSubstring = string.indexOf( substring );
 
-	if( options.caseSensitive
+	if ( options.caseSensitive
 		&& (
 			!options.withinString && indexOfSubstring !== 0
 			|| options.withinString && indexOfSubstring === -1
 		)
 	) {
 		return string;
-	} else if( !options.caseSensitive ) {
+	} else if ( !options.caseSensitive ) {
 		var lowerCaseString = string.toLowerCase(),
 			lowerCaseSubstring = substring.toLowerCase(),
 			caseInsensitiveIndexOfSubstring = lowerCaseString.indexOf( lowerCaseSubstring );
 
-		if(
-			!options.withinString && caseInsensitiveIndexOfSubstring !== 0
+		if ( !options.withinString && caseInsensitiveIndexOfSubstring !== 0
 			|| options.withinString && caseInsensitiveIndexOfSubstring === -1
 		) {
 			return string;
@@ -68,13 +67,13 @@ util.highlightSubstring = function( substring, string, options ) {
 		new RegExp( regExpString, options.caseSensitive ? '' : 'i' )
 	);
 
-	if( matches ) {
+	if ( matches ) {
 		var wrapped = document.createElement( options.wrapperNodeName ),
 			container = document.createElement( 'div' );
 
 		wrapped.appendChild( document.createTextNode( matches[2] ) );
 
-		if( options.wrapperNodeClass ) {
+		if ( options.wrapperNodeClass ) {
 			wrapped.setAttribute( 'class', options.wrapperNodeClass );
 		}
 

--- a/src/ExpertExtender/ExpertExtender.CalendarHint.js
+++ b/src/ExpertExtender/ExpertExtender.CalendarHint.js
@@ -90,13 +90,13 @@
 		 */
 		draw: function() {
 			var value = this._getUpstreamValue();
-			if( !value ) {
+			if ( !value ) {
 				return;
 			}
 
 			var assumeCalendar = value.getYear() <= 1581 || value.getYear() >= 1930;
 
-			if( assumeCalendar || value.getOption( 'precision' ) <= 10 ) {
+			if ( assumeCalendar || value.getOption( 'precision' ) <= 10 ) {
 				this.$calendarhint.hide();
 				return;
 			}
@@ -106,7 +106,7 @@
 					this._prefix + '-' + TimeValue.getCalendarModelKeyByUri( calendarModel )
 				);
 
-			if( !msg ) {
+			if ( !msg ) {
 				return;
 			}
 
@@ -119,7 +119,7 @@
 			msg = this._messageProvider.getMessage(
 				this._prefix + '-switch-' + TimeValue.getCalendarModelKeyByUri( this._otherCalendar )
 			);
-			if( msg ) {
+			if ( msg ) {
 				this.$calendarhint.children( '.' + this._prefix + '-switch' ).html( msg );
 			}
 

--- a/src/ExpertExtender/ExpertExtender.Container.js
+++ b/src/ExpertExtender/ExpertExtender.Container.js
@@ -73,7 +73,7 @@
 		 * @param {*[]} [args]
 		 */
 		_callChild: function( method, args ) {
-			if( this._child[method] ) {
+			if ( this._child[method] ) {
 				this._child[method].apply( this._child, args || [] );
 			}
 		}

--- a/src/ExpertExtender/ExpertExtender.LanguageSelector.js
+++ b/src/ExpertExtender/ExpertExtender.LanguageSelector.js
@@ -84,7 +84,7 @@
 
 			var self = this;
 
-			if( languages !== null ) {
+			if ( languages !== null ) {
 				this._labels = {};
 				$.each( languages, function( i, code ) {
 					self._labels[code] = self._messageProvider.getMessage(
@@ -103,7 +103,7 @@
 		init: function( $extender ) {
 			this._initLabels();
 
-			if( this._labels ) {
+			if ( this._labels ) {
 				this.$selector.languagesuggester( {
 					source: $.map( this._labels, function( label, code ) {
 						return { code: code, label: label };
@@ -123,7 +123,7 @@
 		 */
 		onInitialShow: function() {
 			var value = this._getUpstreamValue();
-			if( this._labels ) {
+			if ( this._labels ) {
 				// Necessary for mapping to the language code if the language is not changed.
 				// FIXME: This is obviously an access violation, and it's probably not a good idea
 				// to track this through the suggester given the current design.

--- a/src/ExpertExtender/ExpertExtender.Listrotator.js
+++ b/src/ExpertExtender/ExpertExtender.Listrotator.js
@@ -70,7 +70,7 @@
 
 			this.rotator.element
 			.on( listrotatorEvents, function( event, newValue ) {
-				if( newValue !== self._getUpstreamValue() ) {
+				if ( newValue !== self._getUpstreamValue() ) {
 					self._onValueChange( newValue );
 				}
 			} )
@@ -84,26 +84,26 @@
 		 */
 		draw: function() {
 			var value = this._getUpstreamValue();
-			if( value === undefined || value === null ) {
+			if ( value === undefined || value === null ) {
 				return;
 			}
 
-			if( this._$customItem ) {
+			if ( this._$customItem ) {
 				this.rotator.options.values.splice( this._customValueIndex, 1 );
 				this._$customItem.remove();
 				this._$customItem = null;
 				this._customValueIndex = null;
 			}
-			if( value.custom ) {
+			if ( value.custom ) {
 				this._customValueIndex = this.rotator.options.values.push( value ) - 1;
 				this._$customItem = this.rotator._addMenuItem( value );
 				value = value.value;
 			}
 
-			if( this.rotator.autoActive() || this._$customItem ) {
+			if ( this.rotator.autoActive() || this._$customItem ) {
 				this.rotator.value( value );
 				this.rotator._setValue( value );
-				if( this._$customItem ) {
+				if ( this._$customItem ) {
 					this.rotator.$menu.data( 'menu' ).refresh();
 					this.rotator.activate(); // disables autoActive state
 				}
@@ -114,7 +114,7 @@
 		 * Callback for the `destroy` `ExpertExtender` event.
 		 */
 		destroy: function() {
-			if( this.rotator ) {
+			if ( this.rotator ) {
 				this.rotator.destroy();
 				this.rotator = null;
 			}

--- a/src/ExpertExtender/ExpertExtender.Preview.js
+++ b/src/ExpertExtender/ExpertExtender.Preview.js
@@ -80,7 +80,7 @@
 		 * Public method for replacing the preview with a spinner.
 		 */
 		showSpinner: function() {
-			if( this._preview ) {
+			if ( this._preview ) {
 				this._preview.showSpinner();
 			}
 		}

--- a/src/ExpertExtender/ExpertExtender.Toggler.js
+++ b/src/ExpertExtender/ExpertExtender.Toggler.js
@@ -65,7 +65,7 @@
 		 */
 		destroy: function() {
 			var toggler = this.$toggler.data( 'toggler' );
-			if( toggler ) {
+			if ( toggler ) {
 				toggler.destroy();
 			}
 			this.$toggler = null;

--- a/src/ExpertExtender/ExpertExtender.UnitSelector.js
+++ b/src/ExpertExtender/ExpertExtender.UnitSelector.js
@@ -93,7 +93,7 @@
 			var upstreamValue = this._getUpstreamValue(),
 				value = upstreamValue ? upstreamValue.label : null;
 
-			if( value === '1' ||
+			if ( value === '1' ||
 				value === 'http://qudt.org/vocab/unit#Unitless' ||
 				/^(?:https?:)?\/\/(?:www\.)?wikidata\.org\/\w+\/Q199$/i.test( value )
 			) {

--- a/src/ExpertExtender/ExpertExtender.js
+++ b/src/ExpertExtender/ExpertExtender.js
@@ -62,7 +62,7 @@
 		 * Callback for expert `draw`.
 		 */
 		draw: function() {
-			if( this._inputextender.extensionIsVisible() ) {
+			if ( this._inputextender.extensionIsVisible() ) {
 				this._extendable.callExtensions( 'draw' );
 			}
 		},
@@ -72,7 +72,7 @@
 		 */
 		destroy: function() {
 			// Since inputextender is created in init, it might not be set
-			if( this._inputextender ) {
+			if ( this._inputextender ) {
 				this._inputextender.destroy();
 				this._inputextender = null;
 			}

--- a/src/experts/GlobeCoordinateInput.js
+++ b/src/experts/GlobeCoordinateInput.js
@@ -37,7 +37,7 @@
 			},
 			function() {
 				var value = self.viewState().value();
-				if( !value ) {
+				if ( !value ) {
 					return value;
 				}
 				value = value.getValue().getPrecision();
@@ -94,14 +94,14 @@
 		 * @inheritdoc
 		 */
 		valueCharacteristics: function() {
-			if( !this.precisionRotator ) { // happens when called statically
+			if ( !this.precisionRotator ) { // happens when called statically
 				return {};
 			}
 
 			var options = {},
 				precision = this.precisionRotator.getValue();
 
-			if( precision !== null ) {
+			if ( precision !== null ) {
 				options.precision = precision;
 			}
 
@@ -141,7 +141,7 @@
 			roundedPrecision = roundPrecision( precision );
 
 		$.each( PRECISIONS, function( i, precision ) {
-			if( roundPrecision( precision ) === roundedPrecision ) {
+			if ( roundPrecision( precision ) === roundedPrecision ) {
 				actualPrecision = roundedPrecision;
 				return false;
 			}

--- a/src/experts/MonolingualText.js
+++ b/src/experts/MonolingualText.js
@@ -47,7 +47,7 @@
 		 */
 		valueCharacteristics: function() {
 			var options = {};
-			if( this._languageSelector ) {
+			if ( this._languageSelector ) {
 				options.valuelang = this._languageSelector.getValue();
 			}
 			return options;

--- a/src/experts/QuantityInput.js
+++ b/src/experts/QuantityInput.js
@@ -59,7 +59,7 @@
 				unit: this._unitSelector && this._unitSelector.getConceptUri() || null
 			};
 
-			if( format === 'text/plain' ) {
+			if ( format === 'text/plain' ) {
 				options.applyRounding = false;
 				options.applyUnit = false;
 			}

--- a/src/experts/StringValue.js
+++ b/src/experts/StringValue.js
@@ -35,7 +35,7 @@
 			.val( this.viewState().getTextValue() )
 			.on( 'keydown', function( event ) {
 				// Prevent Enter key from adding a new line character:
-				if( event.keyCode === $.ui.keyCode.ENTER ) {
+				if ( event.keyCode === $.ui.keyCode.ENTER ) {
 					event.preventDefault();
 				}
 			} )
@@ -51,7 +51,7 @@
 		 * @inheritdoc
 		 */
 		destroy: function() {
-			if( this.$input ) {
+			if ( this.$input ) {
 				this.$input.off( 'eachchange' );
 				this.$input = null;
 			}

--- a/src/experts/TimeInput.js
+++ b/src/experts/TimeInput.js
@@ -141,10 +141,10 @@
 				precision = this.precisionRotator && this.precisionRotator.getValue() || null,
 				calendarUri = this.calendarRotator && this.calendarRotator.getValue() || null;
 
-			if( precision !== null ) {
+			if ( precision !== null ) {
 				options.precision = precision;
 			}
-			if( calendarUri !== null ) {
+			if ( calendarUri !== null ) {
 				options.calendar = calendarUri;
 			}
 
@@ -161,7 +161,7 @@
 		var precisionValues = [],
 			dayPrecision = TimeValue.getPrecisionById( 'DAY' );
 		$.each( TimeValue.PRECISIONS, function( precisionValue, precision ) {
-			if( precisionValue <= dayPrecision ) {
+			if ( precisionValue <= dayPrecision ) {
 				// TODO: Remove this check as soon as time values are supported.
 				precisionValues.unshift( { value: precisionValue, label: precision.text } );
 			}

--- a/src/experts/UnsupportedValue.js
+++ b/src/experts/UnsupportedValue.js
@@ -45,7 +45,7 @@
 				unsupportedIndicator,
 				unsupportedMsg;
 
-			if( !value && this.viewState().option( 'dataTypeId' ) ) {
+			if ( !value && this.viewState().option( 'dataTypeId' ) ) {
 				unsupportedIndicator = this.viewState().option( 'dataTypeId' );
 				unsupportedMsg = this._messageProvider.getMessage(
 					'valueview-expert-unsupportedvalue-unsupporteddatatype',
@@ -53,7 +53,7 @@
 				);
 				// NOTE: Of course, this also implies that the data value type is unsupported but
 				//  the message is actually more detailed than that.
-			} else if( value || this.viewState().option( 'dataValueType' ) ) {
+			} else if ( value || this.viewState().option( 'dataValueType' ) ) {
 				var dataValueType = ( value )
 					? value.getType()
 					: this.viewState().option( 'dataValueType' );

--- a/src/jquery.valueview.Expert.js
+++ b/src/jquery.valueview.Expert.js
@@ -32,13 +32,13 @@ jQuery.valueview = jQuery.valueview || {};
 	vv.expert = function( name, base, constructorOrExpertDefinition, expertDefinition ) {
 		var constructor = null;
 
-		if( expertDefinition ) {
+		if ( expertDefinition ) {
 			constructor = constructorOrExpertDefinition;
 		} else {
 			expertDefinition = constructorOrExpertDefinition;
 		}
 
-		if( !$.isFunction( base ) ) {
+		if ( !$.isFunction( base ) ) {
 			throw new Error( 'The expert\'s base must be a constructor function' );
 		}
 
@@ -93,23 +93,23 @@ jQuery.valueview = jQuery.valueview || {};
 	 * @throws {Error} if neither `messages` nor `messageProvider` is given.
 	 */
 	vv.Expert = function( viewPortNode, relatedViewState, valueViewNotifier, options ) {
-		if( !( relatedViewState instanceof vv.ViewState ) ) {
+		if ( !( relatedViewState instanceof vv.ViewState ) ) {
 			throw new Error( 'No ViewState object was provided to the valueview expert' );
 		}
 
-		if( !valueViewNotifier ) {
+		if ( !valueViewNotifier ) {
 			valueViewNotifier = util.Notifier();
-		} else if( !( valueViewNotifier instanceof util.Notifier ) ) {
+		} else if ( !( valueViewNotifier instanceof util.Notifier ) ) {
 			throw new Error( 'No Notifier object was provided to the valueview expert' );
 		}
 
-		if( viewPortNode instanceof $
+		if ( viewPortNode instanceof $
 			&& viewPortNode.length === 1
 		) {
 			viewPortNode = viewPortNode.get( 0 );
 		}
 
-		if( !( viewPortNode.nodeType ) ) { // IE8 can't check for instanceof HTMLElement
+		if ( !( viewPortNode.nodeType ) ) { // IE8 can't check for instanceof HTMLElement
 			throw new Error( 'No sufficient DOM node provided for the valueview expert' );
 		}
 
@@ -120,16 +120,16 @@ jQuery.valueview = jQuery.valueview || {};
 
 		this._options = $.extend( ( !this._options ) ? {} : this._options, options || {} );
 
-		if( this._options.messages ) {
+		if ( this._options.messages ) {
 			this._messageProvider = new util.HashMessageProvider( this._options.messages );
 		}
-		if( this._options.messageProvider ) {
+		if ( this._options.messageProvider ) {
 			this._messageProvider = new util.CombiningMessageProvider(
 				this._options.messageProvider,
 				this._messageProvider
 			);
 		}
-		if( !this._messageProvider ) {
+		if ( !this._messageProvider ) {
 			throw new Error( 'No message provider and no messages were provided to the valueview expert' );
 		}
 
@@ -223,7 +223,7 @@ jQuery.valueview = jQuery.valueview || {};
 		 * construction, let the responsible controller use a value formatter for that.
 		 */
 		destroy: function() {
-			if( !this.$viewPort ) {
+			if ( !this.$viewPort ) {
 				return; // destroyed already
 			}
 			this._extendable.callExtensions( 'destroy' );

--- a/src/jquery.valueview.ExpertStore.js
+++ b/src/jquery.valueview.ExpertStore.js
@@ -56,11 +56,11 @@ jQuery.valueview = jQuery.valueview || {};
 		registerDataTypeExpert: function( Expert, dataTypeId ) {
 			assertIsExpertConstructor( Expert );
 
-			if( dataTypeId === undefined ) {
+			if ( dataTypeId === undefined ) {
 				throw new Error( 'No proper data type id provided to register the expert for' );
 			}
 
-			if( this._expertsForDataTypes[dataTypeId] ) {
+			if ( this._expertsForDataTypes[dataTypeId] ) {
 				throw new Error( 'Expert for data type "' + dataTypeId + '" is registered already' );
 			}
 
@@ -79,11 +79,11 @@ jQuery.valueview = jQuery.valueview || {};
 		registerDataValueExpert: function( Expert, dataValueType ) {
 			assertIsExpertConstructor( Expert );
 
-			if( dataValueType === undefined ) {
+			if ( dataValueType === undefined ) {
 				throw new Error( 'No proper data value type provided to register the expert for' );
 			}
 
-			if( this._expertsForDataValueTypes[dataValueType] ) {
+			if ( this._expertsForDataValueTypes[dataValueType] ) {
 				throw new Error( 'Expert for data value type "' + dataValueType + '" is registered '
 					+ 'already' );
 			}
@@ -105,13 +105,13 @@ jQuery.valueview = jQuery.valueview || {};
 		getExpert: function( dataValueType, dataTypeId ) {
 			var expert;
 
-			if( typeof dataTypeId === 'string' ) {
+			if ( typeof dataTypeId === 'string' ) {
 				expert = this._expertsForDataTypes[dataTypeId];
 			}
 
-			if( !expert && typeof dataValueType === 'string' ) {
+			if ( !expert && typeof dataValueType === 'string' ) {
 				expert = this._expertsForDataValueTypes[dataValueType];
-			} else if( !expert ) {
+			} else if ( !expert ) {
 				throw new Error( 'No sufficient purpose provided for choosing an expert' );
 			}
 
@@ -126,7 +126,7 @@ jQuery.valueview = jQuery.valueview || {};
 	 * @throws {Error} if the provided argument is not a `jQuery.valueview.Expert` constructor.
 	 */
 	function assertIsExpertConstructor( Expert ) {
-		if( !( $.isFunction( Expert ) && Expert.prototype instanceof $.valueview.Expert ) ) {
+		if ( !( $.isFunction( Expert ) && Expert.prototype instanceof $.valueview.Expert ) ) {
 			throw new Error( 'Invalid jQuery.valueview.Expert constructor' );
 		}
 	}

--- a/src/jquery.valueview.ViewState.js
+++ b/src/jquery.valueview.ViewState.js
@@ -20,7 +20,7 @@ jQuery.valueview = jQuery.valueview || {};
 	 * @throws {Error} if no `jQuery.valueview` instance is provided.
 	 */
 	var SELF = vv.ViewState = function ValueviewViewState( valueview ) {
-		if( !( valueview instanceof vv.valueview ) ) {
+		if ( !( valueview instanceof vv.valueview ) ) {
 			throw new Error( 'Can not create a valueview ViewState object without a valueview' );
 		}
 		this._view = valueview;

--- a/src/jquery.valueview.valueview.js
+++ b/src/jquery.valueview.valueview.js
@@ -14,7 +14,7 @@ var PARENT = $.Widget;
  */
 function expertProxy( fnName ) {
 	return function() {
-		if( this._expert && this.isInEditMode() ) {
+		if ( this._expert && this.isInEditMode() ) {
 			return this._expert[ fnName ].apply( this._expert, arguments );
 		}
 	};
@@ -197,8 +197,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	 * @throws {Error} if a required option is not specified properly.
 	 */
 	_create: function() {
-		if(
-			!this.options.expertStore
+		if ( !this.options.expertStore
 			|| !this.options.parserStore
 			|| !this.options.formatterStore
 			|| typeof this.options.language !== 'string'
@@ -215,7 +214,7 @@ $.widget( 'valueview.valueview', PARENT, {
 		// Set initial value if provided in options:
 		this._initValue( this.option( 'value' ) || null );
 
-		if( this.option( 'autoStartEditing' ) && this.isEmpty() ) {
+		if ( this.option( 'autoStartEditing' ) && this.isEmpty() ) {
 			// If no data value is represented, offer UI to build one.
 			this.startEditing();
 		}
@@ -233,7 +232,7 @@ $.widget( 'valueview.valueview', PARENT, {
 				+ this.widgetBaseClass + '-ineditmode '
 		);
 
-		if( this._expert ) {
+		if ( this._expert ) {
 			this._destroyExpert();
 		}
 
@@ -247,7 +246,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	 * @throws {Error} when trying to set an option that cannot be set after initialization.
 	 */
 	_setOption: function( key, value ) {
-		switch( key ) {
+		switch ( key ) {
 			case 'autoStartEditing':
 				// doesn't make sense to change this after initialization
 				throw new Error( 'Can not change jQuery.valueview option "' + key
@@ -256,7 +255,7 @@ $.widget( 'valueview.valueview', PARENT, {
 
 		PARENT.prototype._setOption.call( this, key, value );
 
-		switch( key ) {
+		switch ( key ) {
 			case 'expertStore':
 			case 'dataTypeId': // TODO: make this work properly and test
 			case 'dataValueType':
@@ -277,7 +276,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	startEditing: function() {
 		var self = this;
 
-		if( this.isInEditMode() ) {
+		if ( this.isInEditMode() ) {
 			return; // return nothing to allow chaining
 		}
 
@@ -303,7 +302,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	 *        started will be reinstated.
 	 */
 	stopEditing: function( dropValue ) {
-		if( !this.isInEditMode() ) {
+		if ( !this.isInEditMode() ) {
 			return;
 		}
 
@@ -311,7 +310,7 @@ $.widget( 'valueview.valueview', PARENT, {
 
 		var self = this;
 
-		if( dropValue ) {
+		if ( dropValue ) {
 			// reinstate initial value from before edit mode
 			this.value( this.initialValue() );
 		}
@@ -319,7 +318,7 @@ $.widget( 'valueview.valueview', PARENT, {
 		this._initialValue = null;
 		this._isInEditMode = false;
 		delete this.__lastValueCharacteristics;
-		if( this._expert ) {
+		if ( this._expert ) {
 			this._destroyExpert();
 		}
 
@@ -353,7 +352,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	 * If its not in edit mode, the current value will be returned.
 	 */
 	initialValue: function() {
-		if( !this.isInEditMode() ) {
+		if ( !this.isInEditMode() ) {
 			return this.value();
 		}
 		return this._initialValue;
@@ -386,10 +385,10 @@ $.widget( 'valueview.valueview', PARENT, {
 	 * @throws {Error} if value provided is not a `dataValues.DataValue` instance.
 	 */
 	value: function( value ) {
-		if( value === undefined ) {
+		if ( value === undefined ) {
 			return this._value;
 		}
-		if( value !== null && !( value instanceof dv.DataValue ) ) {
+		if ( value !== null && !( value instanceof dv.DataValue ) ) {
 			throw new Error( 'The given value has to be an instance of dataValues.DataValue or '
 				+ 'null' );
 		}
@@ -404,7 +403,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	 */
 	_initValue: function( value ) {
 		var formattedValue = this.element.html();
-		if( !formattedValue ) {
+		if ( !formattedValue ) {
 			return this.value( value );
 		} else {
 			this._value = value;
@@ -424,14 +423,13 @@ $.widget( 'valueview.valueview', PARENT, {
 	 */
 	_setValue: function( value ) {
 		// Check whether given value is actually suitable for the widget:
-		if(
-			value !== null // null represents empty value
-			&& ( !( value instanceof dv.DataValue ) )
+		if ( value !== null // null represents empty value
+			&& !( value instanceof dv.DataValue )
 		) {
 			throw new Error( 'Instance of dataValues.DataValue required for setting a value' );
 		}
 
-		if( this._value && value && JSON.stringify( value.toJSON() ) === JSON.stringify( this._value.toJSON() ) ) {
+		if ( this._value && value && JSON.stringify( value.toJSON() ) === JSON.stringify( this._value.toJSON() ) ) {
 			return;
 		}
 
@@ -444,7 +442,7 @@ $.widget( 'valueview.valueview', PARENT, {
 
 		var self = this;
 
-		if( this._value === null ) {
+		if ( this._value === null ) {
 			this._formattedValue = null;
 			this.draw();
 		} else {
@@ -456,7 +454,7 @@ $.widget( 'valueview.valueview', PARENT, {
 					self.draw();
 				} )
 				.fail( function( message ) {
-					if( message ) {
+					if ( message ) {
 						self._renderError( message );
 					}
 				} );
@@ -481,7 +479,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	 * @throws {Error} if current text value is null.
 	 */
 	getTextValue: function() {
-		if( this._textValue === null ) {
+		if ( this._textValue === null ) {
 			throw new Error( 'This cannot happen' );
 		}
 		return this._textValue;
@@ -515,7 +513,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	 *         set in the options.
 	 */
 	_updateExpertConstructor: function() {
-		if( !( this.options.expertStore instanceof $.valueview.ExpertStore ) ) {
+		if ( !( this.options.expertStore instanceof $.valueview.ExpertStore ) ) {
 			throw new Error( 'No ExpertStore set in valueview\'s "expertStore" option' );
 		}
 
@@ -523,7 +521,7 @@ $.widget( 'valueview.valueview', PARENT, {
 
 		this._expertConstructor = $.valueview.experts.EmptyValue;
 
-		if( dataValueType || this.options.dataTypeId ) {
+		if ( dataValueType || this.options.dataTypeId ) {
 			this._expertConstructor = this.options.expertStore.getExpert(
 				dataValueType,
 				this.options.dataTypeId
@@ -538,8 +536,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	 * @private
 	 */
 	_updateExpert: function() {
-		if(
-			this._expert && this._expertConstructor
+		if ( this._expert && this._expertConstructor
 			&& this._expert.constructor === this._expertConstructor.prototype.constructor
 		) {
 			return; // fully compatible expert
@@ -547,11 +544,11 @@ $.widget( 'valueview.valueview', PARENT, {
 
 		// Previous expert not suitable for the new task!
 		// Destroy old expert, create new one suitable for value:
-		if( this._expert ) {
+		if ( this._expert ) {
 			this._destroyExpert();
 		}
 
-		if( this._expertConstructor ) {
+		if ( this._expertConstructor ) {
 			this._expert = new this._expertConstructor(
 				this.$value,
 				this.viewState(),
@@ -604,9 +601,9 @@ $.widget( 'valueview.valueview', PARENT, {
 		var self = this,
 			deferred = $.Deferred();
 
-		if( this.isInEditMode() ) {
+		if ( this.isInEditMode() ) {
 			this._updateTextValue().then( function () {
-				if( !self.isInEditMode() ) {
+				if ( !self.isInEditMode() ) {
 					// edit mode was left while formatting text value
 					return;
 				}
@@ -615,7 +612,7 @@ $.widget( 'valueview.valueview', PARENT, {
 
 				// TODO: Display message that data value type is unsupported or no expert indicator
 				//  and no value at the same time:
-				// if( !self._expert ) { ... }
+				// if ( !self._expert ) { ... }
 
 				self._expert.draw()
 				.done( function() {
@@ -662,7 +659,7 @@ $.widget( 'valueview.valueview', PARENT, {
 			.done( function( parsedValue ) {
 				self._value = parsedValue;
 
-				if( self._value === null ) {
+				if ( self._value === null ) {
 					self._formattedValue = null;
 					self.drawContent();
 					return;
@@ -674,7 +671,7 @@ $.widget( 'valueview.valueview', PARENT, {
 						self.drawContent();
 					} )
 					.fail( function( message ) {
-						if( message ) {
+						if ( message ) {
 							self._formattedValue = null;
 							self._renderError( message );
 						}
@@ -682,7 +679,7 @@ $.widget( 'valueview.valueview', PARENT, {
 
 			} )
 			.fail( function( message ) {
-				if( message ) {
+				if ( message ) {
 					self._value = null;
 					self._renderError( message );
 				}
@@ -696,7 +693,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	 * @param {string} message HTML error message.
 	 */
 	_renderError: function( message ) {
-		if( this._expert && this._expert.preview ) {
+		if ( this._expert && this._expert.preview ) {
 			this._expert.preview.update( message );
 		}
 	},
@@ -722,14 +719,14 @@ $.widget( 'valueview.valueview', PARENT, {
 
 		this._trigger( 'parse' );
 
-		if( rawValue === null || rawValue instanceof dv.DataValue ) {
+		if ( rawValue === null || rawValue instanceof dv.DataValue ) {
 			this.__lastUpdateValue = undefined;
 			self._trigger( 'afterparse' );
 			deferred.resolve( rawValue );
 			return deferred.promise();
 		}
 
-		if( this._parseTimer ) {
+		if ( this._parseTimer ) {
 			clearTimeout( this._parseTimer );
 		}
 
@@ -742,18 +739,18 @@ $.widget( 'valueview.valueview', PARENT, {
 			//  for previews out of the experts. The preview should be handled in the same place for
 			//  all value types, could perhaps move into its own widget, listening to valueview
 			//  events.
-			if( expert && expert.preview ) {
+			if ( expert && expert.preview ) {
 				expert.preview.showSpinner();
 			}
 
 			valueParser.parse( rawValue )
 				.done( function( parsedValue ) {
 					// Paranoia check against ValueParser interface:
-					if( parsedValue !== null && !( parsedValue instanceof dv.DataValue ) ) {
+					if ( parsedValue !== null && !( parsedValue instanceof dv.DataValue ) ) {
 						throw new Error( 'Unexpected value parser result' );
 					}
 
-					if( self.__lastUpdateValue === undefined || self.__lastUpdateValue !== rawValue ) {
+					if ( self.__lastUpdateValue === undefined || self.__lastUpdateValue !== rawValue ) {
 						// latest update job is done, this one must be a late response for some weird
 						// reason, or the value has since been updated, so should be re-parsed
 						// and this result be rejected and ignored.
@@ -789,7 +786,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	 *         set in the options.
 	 */
 	_instantiateParser: function( additionalParserOptions ) {
-		if( !( this.options.parserStore instanceof vp.ValueParserStore ) ) {
+		if ( !( this.options.parserStore instanceof vp.ValueParserStore ) ) {
 			throw new Error( 'No value parser store in valueview\'s options specified' );
 		}
 
@@ -829,7 +826,7 @@ $.widget( 'valueview.valueview', PARENT, {
 
 		valueFormatter.format( dataValue, dataTypeId, 'text/html' )
 			.done( function( formattedValue, formattedDataValue ) {
-				if( dataValue === formattedDataValue ) {
+				if ( dataValue === formattedDataValue ) {
 					deferred.resolve( formattedValue );
 				} else {
 					// Late response that should be ignored.
@@ -865,7 +862,7 @@ $.widget( 'valueview.valueview', PARENT, {
 			dataTypeId = this.options.dataTypeId || null,
 			dataValue = this._value;
 
-		if( !dataValue ) {
+		if ( !dataValue ) {
 			self._textValue = '';
 			deferred.resolve();
 			return deferred.promise();
@@ -875,7 +872,7 @@ $.widget( 'valueview.valueview', PARENT, {
 
 		valueFormatter.format( dataValue, dataTypeId, format )
 			.done( function( formattedValue, formattedDataValue ) {
-				if( dataValue === formattedDataValue ) {
+				if ( dataValue === formattedDataValue ) {
 					self._textValue = formattedValue;
 					deferred.resolve();
 				} else {
@@ -900,7 +897,7 @@ $.widget( 'valueview.valueview', PARENT, {
 	 *         `valueFormatters.ValueFormatterStore` is set in the options.
 	 */
 	_instantiateFormatter: function( additionalFormatterOptions ) {
-		if( !( this.options.formatterStore instanceof vf.ValueFormatterStore ) ) {
+		if ( !( this.options.formatterStore instanceof vf.ValueFormatterStore ) ) {
 			throw new Error( 'No value formatter store in valueview\'s options specified' );
 		}
 
@@ -956,7 +953,7 @@ $.widget( 'valueview.valueview', PARENT, {
 			change: function() {
 				var i;
 
-				if( !self._expert ) {
+				if ( !self._expert ) {
 					// someone notified about change while there couldn't have been one since there
 					// is no expert which allows for any change currently...
 					return;
@@ -969,11 +966,11 @@ $.widget( 'valueview.valueview', PARENT, {
 					newValueCharacteristics = self._expert.valueCharacteristics(),
 					lastValueCharacteristics = self.__lastValueCharacteristics || {};
 
-				for( i in newValueCharacteristics ) {
+				for ( i in newValueCharacteristics ) {
 					differentValueCharacteristics = differentValueCharacteristics
 					|| newValueCharacteristics[i] !== lastValueCharacteristics[i];
 				}
-				for( i in lastValueCharacteristics ) {
+				for ( i in lastValueCharacteristics ) {
 					differentValueCharacteristics = differentValueCharacteristics
 					|| newValueCharacteristics[i] !== lastValueCharacteristics[i];
 				}
@@ -981,7 +978,7 @@ $.widget( 'valueview.valueview', PARENT, {
 				var changeDetected
 					= differentValueCharacteristics || self.getTextValue() !== self._expert.rawValue();
 
-				if( changeDetected ) {
+				if ( changeDetected ) {
 					self.__lastValueCharacteristics = newValueCharacteristics;
 					self._trigger( 'change' );
 					self._updateValue();
@@ -997,10 +994,10 @@ $.widget( 'valueview.valueview', PARENT, {
 	 * @return {Object}
 	 */
 	valueCharacteristics: function( format ) {
-		if( this._expert ) {
+		if ( this._expert ) {
 			return this._expert.valueCharacteristics( format );
 		}
-		if( this._expertConstructor ) {
+		if ( this._expertConstructor ) {
 			return this._expertConstructor.prototype.valueCharacteristics( format );
 		}
 		return {};

--- a/tests/lib/jquery.ui/jquery.ui.inputextender.tests.js
+++ b/tests/lib/jquery.ui/jquery.ui.inputextender.tests.js
@@ -17,7 +17,7 @@
 	 * @param {jQuery} [$input] Subject node for the widget.
 	 */
 	var newTestInputextender = function( options, $input ) {
-		if( $input === undefined && options instanceof $ ) {
+		if ( $input === undefined && options instanceof $ ) {
 			$input = options;
 			options = undefined;
 		}
@@ -55,7 +55,7 @@
 	 */
 	function showAndHideExtensionAgain( instance, hideControl, callbacks ) {
 		var deferred = $.Deferred();
-		if( !hideControl.done ) {
+		if ( !hideControl.done ) {
 			callbacks = hideControl;
 			// We will do the hideExtension() immediately in this case:
 			hideControl = $.Deferred().resolve().promise();
@@ -93,7 +93,7 @@
 		teardown: function() {
 			$( '.test_inputextender' ).each( function( i, node ) {
 				var inputextender = $( node ).data( 'inputextender' );
-				if( inputextender ) {
+				if ( inputextender ) {
 					inputextender.destroy();
 				}
 				$( node ).remove();
@@ -117,7 +117,7 @@
 
 	QUnit.test( 'Initialization on focused input', function( assert ) {
 		var $input = $( '<input/>' ).appendTo( $( 'body' ) ).focus();
-		if( !$input.is( ':focus' ) ) {
+		if ( !$input.is( ':focus' ) ) {
 			assert.ok( true, 'Could not test since focussing does not work.' );
 			return;
 		}
@@ -252,7 +252,7 @@
 		// one will be made inactive and so on.
 		var hideControl = $.Deferred();
 
-		if( inactiveExtenders.length < 1 ) {
+		if ( inactiveExtenders.length < 1 ) {
 			return hideControl.resolve().promise();
 		}
 
@@ -292,7 +292,7 @@
 
 		// Build a few instances for the test:
 		var extenders = [];
-		while( extenders.length < 5 ) {
+		while ( extenders.length < 5 ) {
 			extenders.push( newTestInputextender() );
 		}
 		testGetInstancesWithVisibleExtensions( assert, extenders );

--- a/tests/lib/jquery.ui/jquery.ui.listrotator.tests.js
+++ b/tests/lib/jquery.ui/jquery.ui.listrotator.tests.js
@@ -31,7 +31,7 @@
 			$( '.test_listrotator' ).each( function( i, node ) {
 				var $node = $( node ),
 					listRotator = $node.data( 'listrotator' );
-				if( listRotator ) {
+				if ( listRotator ) {
 					listRotator.destroy();
 				}
 				$node.remove();

--- a/tests/lib/jquery.ui/jquery.ui.ooMenu.tests.js
+++ b/tests/lib/jquery.ui/jquery.ui.ooMenu.tests.js
@@ -570,7 +570,7 @@
 			['label', null, function() { return 'action'; }, 'cssClass', 'someLink']
 		];
 
-		for( var i = 0; i < testSets.length; i++ ) {
+		for ( var i = 0; i < testSets.length; i++ ) {
 			var args = testSets[i].concat( new Array( 5 - testSets[i].length ) ),
 				item = new $.ui.ooMenu.CustomItem( args[0], args[1], args[2], args[3], args[4] );
 
@@ -581,9 +581,9 @@
 
 			var expectedVisibility = true;
 
-			if( $.isFunction( testSets[i][1] ) ) {
+			if ( $.isFunction( testSets[i][1] ) ) {
 				expectedVisibility = testSets[i][1]();
-			} else if( typeof testSets[i][1] === 'boolean' ) {
+			} else if ( typeof testSets[i][1] === 'boolean' ) {
 				expectedVisibility = testSets[i][1];
 			}
 

--- a/tests/lib/jquery.ui/jquery.ui.preview.tests.js
+++ b/tests/lib/jquery.ui/jquery.ui.preview.tests.js
@@ -13,7 +13,7 @@
 	 * @return {jQuery.ui.preview}
 	 */
 	var newTestPreview = function( options ) {
-		if( !options ) {
+		if ( !options ) {
 			options = $.extend( {}, options );
 		}
 
@@ -28,7 +28,7 @@
 	QUnit.module( 'jquery.ui.preview', {
 		teardown: function() {
 			$( '.test_preview' ).each( function( i, node ) {
-				if( $( node ).data( 'preview' ) ) {
+				if ( $( node ).data( 'preview' ) ) {
 					$( node ).data( 'preview' ).destroy();
 				}
 				$( node ).remove();

--- a/tests/lib/jquery.ui/jquery.ui.suggester.tests.js
+++ b/tests/lib/jquery.ui/jquery.ui.suggester.tests.js
@@ -45,7 +45,7 @@
 		teardown: function() {
 			var $suggester = $( '.test_suggester' ),
 				suggester = $suggester.data( 'suggester' );
-			if( suggester ) {
+			if ( suggester ) {
 				suggester.destroy();
 			}
 			$suggester.remove();

--- a/tests/lib/jquery.ui/jquery.ui.toggler.tests.js
+++ b/tests/lib/jquery.ui/jquery.ui.toggler.tests.js
@@ -29,7 +29,7 @@
 	QUnit.module( 'jquery.ui.toggler', {
 		teardown: function() {
 			$( '.test_toggler' ).each( function( i, node ) {
-				if( $( node ).data( 'toggler' ) ) {
+				if ( $( node ).data( 'toggler' ) ) {
 					$( node ).data( 'toggler' ).destroy();
 				}
 				$( node ).remove();

--- a/tests/lib/jquery/jquery.AnimationEvent.tests.js
+++ b/tests/lib/jquery/jquery.AnimationEvent.tests.js
@@ -144,7 +144,7 @@
 		// Execute all other generated step callbacks as well, verify that they execute and that
 		// they do not trigger the testStep's callback again.
 		$.each( AnimationEvent.ANIMATION_STEPS, function( i, step ) {
-			if( step !== testStep ) {
+			if ( step !== testStep ) {
 				options[ step ]();
 			}
 		} );

--- a/tests/lib/jquery/jquery.animateWithEvent.tests.js
+++ b/tests/lib/jquery/jquery.animateWithEvent.tests.js
@@ -109,11 +109,11 @@
 			var elem = animationEvent.animation.elem;
 			$confirmedElems = $confirmedElems.add( elem );
 
-			if( $.inArray( animationEvent, animationEventInstances ) < 0 ) {
+			if ( $.inArray( animationEvent, animationEventInstances ) < 0 ) {
 				animationEventInstances.push( animationEvent );
 			}
 
-			if( $confirmedElems.length >= $elems.length ) {
+			if ( $confirmedElems.length >= $elems.length ) {
 				QUnit.start();
 			}
 		} ).promise().done( function() {

--- a/tests/lib/jquery/jquery.focusAt.tests.js
+++ b/tests/lib/jquery/jquery.focusAt.tests.js
@@ -14,7 +14,7 @@
 	function getDomInsertionTestViewport() {
 		var body = $( 'body' );
 
-		if( !body.length ) {
+		if ( !body.length ) {
 			throw new Error( 'Can only run this test on a HTML page with "body" tag in the browser.' );
 		}
 		return body;
@@ -87,7 +87,7 @@
 		var $dom = getDomInsertionTestViewport(),
 			elem = params.elem;
 
-		if( !$dom.length ) {
+		if ( !$dom.length ) {
 			throw new Error( 'Can only run this test on a HTML page with "body" tag in the browser.' );
 		}
 
@@ -96,7 +96,7 @@
 				elem.focusAt( 0 ),
 				'Can call focusAt on element not in DOM yet.'
 			);
-		} catch( e ) {
+		} catch ( e ) {
 			assert.ok(
 				e.name === 'NS_ERROR_FAILURE' && e.result === 0x80004005,
 				'Unable to focus since browser requires element to be in the DOM.'
@@ -121,7 +121,7 @@
 			elem = params.elem,
 			isOk;
 
-		if( !$dom.length ) {
+		if ( !$dom.length ) {
 			throw new Error( 'Can only run this test on a HTML page with "body" tag in the browser.' );
 		}
 
@@ -130,7 +130,7 @@
 
 		// Check if focussing actually works
 		elem.focus();
-		if( !elem.is( ':focus' ) ) {
+		if ( !elem.is( ':focus' ) ) {
 			assert.ok( 'Could not test because focussing does not work.' );
 			return;
 		}
@@ -142,7 +142,7 @@
 			'Can call focusAt on element in DOM'
 		);
 
-		if( !params.focusable ) {
+		if ( !params.focusable ) {
 			assert.equal(
 				$( ':focus' ).length,
 				0,

--- a/tests/lib/util/util.highlightSubstring.tests.js
+++ b/tests/lib/util/util.highlightSubstring.tests.js
@@ -18,7 +18,7 @@ QUnit.test( 'Highlight with default options', function( assert ) {
 		['ABCDEF', 'abc', '<span class="highlight">ABC</span>DEF']
 	];
 
-	for( var i = 0; i < testCases.length; i++ ) {
+	for ( var i = 0; i < testCases.length; i++ ) {
 		var string = testCases[i][0],
 			substring = testCases[i][1],
 			expected = testCases[i][2];
@@ -39,7 +39,7 @@ QUnit.test( 'Highlight (caseSensitive === true)', function( assert ) {
 		['ABCDEF', 'ABC', '<span class="highlight">ABC</span>DEF']
 	];
 
-	for( var i = 0; i < testCases.length; i++ ) {
+	for ( var i = 0; i < testCases.length; i++ ) {
 		var string = testCases[i][0],
 			substring = testCases[i][1],
 			expected = testCases[i][2];
@@ -59,7 +59,7 @@ QUnit.test( 'Highlight (withinString === true)', function( assert ) {
 		['abcdef', 'abc', '<span class="highlight">abc</span>def']
 	];
 
-	for( var i = 0; i < testCases.length; i++ ) {
+	for ( var i = 0; i < testCases.length; i++ ) {
 		var string = testCases[i][0],
 			substring = testCases[i][1],
 			expected = testCases[i][2];
@@ -87,7 +87,7 @@ QUnit.test( 'Highlight (wrapperNodeName, wrapperNodeClass)', function( assert ) 
 		}]
 	];
 
-	for( var i = 0; i < testCases.length; i++ ) {
+	for ( var i = 0; i < testCases.length; i++ ) {
 		var string = testCases[i][0],
 			substring = testCases[i][1],
 			expected = testCases[i][2];

--- a/tests/src/ExpertExtender/ExpertExtender.CalendarHint.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.CalendarHint.tests.js
@@ -17,7 +17,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.CalendarHint' );
 
-	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
+	if ( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( ExpertExtender.CalendarHint.prototype, function( cur, tester, path ) {
 			return false;
 		} );

--- a/tests/src/ExpertExtender/ExpertExtender.Container.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.Container.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.Container' );
 
-	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
+	if ( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( ExpertExtender.Container.prototype, function( cur, tester, path ) {
 			return false;
 		} );

--- a/tests/src/ExpertExtender/ExpertExtender.LanguageSelector.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.LanguageSelector.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.LanguageSelector' );
 
-	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
+	if ( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest(
 			ExpertExtender.LanguageSelector.prototype,
 			function( cur, tester, path ) {
@@ -53,11 +53,11 @@
 
 		languageSelector.init( $extender );
 
-		if( languageSelector.onInitialShow ) {
+		if ( languageSelector.onInitialShow ) {
 			languageSelector.onInitialShow();
 		}
 
-		if( languageSelector.draw ) {
+		if ( languageSelector.draw ) {
 			languageSelector.draw();
 		}
 
@@ -65,7 +65,7 @@
 
 		upstreamValue = 'de';
 
-		if( languageSelector.draw ) {
+		if ( languageSelector.draw ) {
 			languageSelector.draw();
 		}
 
@@ -87,11 +87,11 @@
 
 		languageSelector.init( $extender );
 
-		if( languageSelector.onInitialShow ) {
+		if ( languageSelector.onInitialShow ) {
 			languageSelector.onInitialShow();
 		}
 
-		if( languageSelector.draw ) {
+		if ( languageSelector.draw ) {
 			languageSelector.draw();
 		}
 

--- a/tests/src/ExpertExtender/ExpertExtender.Listrotator.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.Listrotator.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.Listrotator' );
 
-	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
+	if ( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( ExpertExtender.Listrotator.prototype, function( cur, tester, path ) {
 			return false;
 		} );

--- a/tests/src/ExpertExtender/ExpertExtender.Preview.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.Preview.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.Preview' );
 
-	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
+	if ( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( ExpertExtender.Preview.prototype, function( cur, tester, path ) {
 			return false;
 		} );

--- a/tests/src/ExpertExtender/ExpertExtender.Toggler.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.Toggler.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.Toggler' );
 
-	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
+	if ( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( ExpertExtender.Toggler.prototype, function( cur, tester, path ) {
 			return false;
 		} );

--- a/tests/src/ExpertExtender/ExpertExtender.UnitSelector.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.UnitSelector.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender.UnitSelector' );
 
-	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
+	if ( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest(
 			ExpertExtender.UnitSelector.prototype,
 			function( cur, tester, path ) {
@@ -46,11 +46,11 @@
 
 		unitSelector.init( $extender );
 
-		if( unitSelector.onInitialShow ) {
+		if ( unitSelector.onInitialShow ) {
 			unitSelector.onInitialShow();
 		}
 
-		if( unitSelector.draw ) {
+		if ( unitSelector.draw ) {
 			unitSelector.draw();
 		}
 
@@ -72,11 +72,11 @@
 
 		unitSelector.init( $extender );
 
-		if( unitSelector.onInitialShow ) {
+		if ( unitSelector.onInitialShow ) {
 			unitSelector.onInitialShow();
 		}
 
-		if( unitSelector.draw ) {
+		if ( unitSelector.draw ) {
 			unitSelector.draw();
 		}
 

--- a/tests/src/ExpertExtender/ExpertExtender.tests.js
+++ b/tests/src/ExpertExtender/ExpertExtender.tests.js
@@ -8,7 +8,7 @@
 
 	QUnit.module( 'jquery.valueview.ExpertExtender' );
 
-	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
+	if ( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( ExpertExtender.prototype, function( cur, tester, path ) {
 			return false;
 		} );
@@ -60,7 +60,7 @@
 		// inputextender immediately extends if $input has focus
 		// If, after focussing, $input does not have focus, we are running in phantomjs
 		// or an unfocused firefox window. Force showing the extension, then.
-		if( !$input.is( ':focus' ) ) {
+		if ( !$input.is( ':focus' ) ) {
 			expertExtender._inputextender.showExtension();
 		}
 

--- a/tests/src/experts/MonolingualText.tests.js
+++ b/tests/src/experts/MonolingualText.tests.js
@@ -11,7 +11,7 @@
 
 	QUnit.module( 'jquery.valueview.experts.MonolingualText' );
 
-	if( QUnit.urlParams.completenesstest ) {
+	if ( QUnit.urlParams.completenesstest ) {
 		new CompletenessTest( expertToTest, function( cur, tester, path ) {
 			return false;
 		} );

--- a/tests/src/jquery.valueview.ExpertStore.tests.js
+++ b/tests/src/jquery.valueview.ExpertStore.tests.js
@@ -29,7 +29,7 @@
 	 * @return {string}
 	 */
 	function getTypeInfo( purpose ) {
-		if( purpose instanceof DataTypeMock ) {
+		if ( purpose instanceof DataTypeMock ) {
 			return 'DataType with data value type "' + purpose.getDataValueType() + '"';
 		}
 		return 'constructor for DataValue of type "' + purpose.TYPE + '"';
@@ -227,7 +227,7 @@
 			var purpose = registerPair[0],
 				Expert = registerPair[1];
 
-			if( purpose instanceof DataTypeMock ) {
+			if ( purpose instanceof DataTypeMock ) {
 				expertStore.registerDataTypeExpert( Expert, purpose.getId() );
 			} else {
 				expertStore.registerDataValueExpert( Expert, purpose.TYPE );
@@ -245,7 +245,7 @@
 				Expert = expectPair[1],
 				RetrievedExpert;
 
-			if( purpose instanceof DataTypeMock ) {
+			if ( purpose instanceof DataTypeMock ) {
 				RetrievedExpert = expertStore.getExpert(
 					purpose.getDataValueType(), purpose.getId()
 				);

--- a/tests/src/jquery.valueview.tests.MockViewState.js
+++ b/tests/src/jquery.valueview.tests.MockViewState.js
@@ -21,7 +21,7 @@ jQuery.valueview.tests.MockViewState = ( function( $, ViewState, util ) {
 	 * @throws {Error} if definition is not a plain object.
 	 */
 	return util.inherit( 'ValueviewMockViewState', ViewState, function ( definition ) {
-		if( definition !== undefined && !$.isPlainObject( definition ) ) {
+		if ( definition !== undefined && !$.isPlainObject( definition ) ) {
 			throw new Error( 'Given definition needs to be a plain object' );
 		}
 		this._view = definition || {};

--- a/tests/src/jquery.valueview.tests.testExpert.js
+++ b/tests/src/jquery.valueview.tests.testExpert.js
@@ -171,7 +171,7 @@ function testExpert( testDefinition ) {
 				true,
 				memberName + '() has been called'
 			);
-			if( additionalAssertionsFn ) {
+			if ( additionalAssertionsFn ) {
 				additionalAssertionsFn( args, assert );
 			}
 		} );
@@ -188,7 +188,7 @@ function testExpert( testDefinition ) {
 	expertCasesTestAndCleanup( 'focus', function( args, assert ) {
 		try {
 			args.expert.focus();
-		} catch( e ) {
+		} catch ( e ) {
 			assert.ok(
 				e.name === 'NS_ERROR_FAILURE' && e.result === 0x80004005,
 				'Unable to focus since browser requires element to be in the DOM.'
@@ -227,7 +227,7 @@ testExpert.basicTestDefinition = {
   *         jQuery.valueview.Expert.
   */
 testExpert.verifyTestDefinition = function( testDefinition ) {
-	if( !testDefinition.expertConstructor
+	if ( !testDefinition.expertConstructor
 		|| !( testDefinition.expertConstructor.prototype instanceof valueview.Expert )
 	) {
 		throw new Error( 'Test definition\'s "expertConstructor" field has to hold a constructor '

--- a/tests/src/jquery.valueview.valueview.tests.js
+++ b/tests/src/jquery.valueview.valueview.tests.js
@@ -12,7 +12,7 @@
 
 	QUnit.module( 'jquery.valueview.valueview' );
 
-	if( QUnit.urlParams.completenesstest && CompletenessTest ) {
+	if ( QUnit.urlParams.completenesstest && CompletenessTest ) {
 		new CompletenessTest( vv.prototype, function( cur, tester, path ) {
 			// Don't check code coverage for options
 			return path[path.length - 1] === 'options';
@@ -25,7 +25,7 @@
 		$vvElem = opts.generateDom();
 		vvInst = $vvElem.valueview( opts.vvArgs ).data( 'valueview' );
 
-		if( opts.withExpert ) {
+		if ( opts.withExpert ) {
 			vvInst.startEditing();
 		}
 	}


### PR DESCRIPTION
This is the most minimal consensus we could come up with, see [T110811](https://phabricator.wikimedia.org/T110811).

This moves the coding style of our code base much, much closer to the MediaWiki code style. Note that we are excluding "function()" for now. This is exactly what JSCS' "google" preset does, which is used by JSCS itself. Also note that major projects like Flow and Parsoid also favor "function()" and therefor disabled the requireSpaceAfterKeywords rule completely.

[Bug: T110811](https://phabricator.wikimedia.org/T110811)